### PR TITLE
Change ign with gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,32 +18,32 @@ Ignition Go provides a set of features to help with web server development. It i
 
 ### Routes
 ```go
-ign.Routes{
-    ign.Route{
+gz.Routes{
+    gz.Route{
         Name:        "Route example",
         Description: "Route description example",
         URI:         "/example",
-        Headers:     ign.AuthHeadersRequired,
-        Methods:     ign.Methods{
-            ign.Method{
+        Headers:     gz.AuthHeadersRequired,
+        Methods:     gz.Methods{
+            gz.Method{
                 Type:        "GET",
                 Description: "Get all the examples",
-                Handlers:    ign.FormatHandlers{
-                    ign.FormatHandler{
+                Handlers:    gz.FormatHandlers{
+                    gz.FormatHandler{
                         Extension: "",
-                        Handler:   ign.JSONResult(/* Your method handler in here */),
+                        Handler:   gz.JSONResult(/* Your method handler in here */),
                     },
                 },
             },
         },
-        SecureMethods: ign.SecureMethods{
-            ign.Method{
+        SecureMethods: gz.SecureMethods{
+            gz.Method{
                 Type:        "POST",
                 Description: "Creates a new example",
-                Handlers:    ign.FormatHandlers{
-                    ign.FormatHandler{
+                Handlers:    gz.FormatHandlers{
+                    gz.FormatHandler{
                         Extension: "",
-                        Handler:   ign.JSONResult(/* Your secure method handler in here */),
+                        Handler:   gz.JSONResult(/* Your secure method handler in here */),
                     },
                 },
             },
@@ -55,7 +55,7 @@ ign.Routes{
 ### Queue
 ```go
 func main() {
-	queue := ign.NewQueue()
+	queue := gz.NewQueue()
 	queue.Enqueue("Value")
 	if v, err := queue.DequeueOrWaitForNextElement(); err == nil {
 		fmt.Println(v)

--- a/access_tokens.go
+++ b/access_tokens.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"crypto/rand"

--- a/aws.go
+++ b/aws.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"errors"

--- a/aws_test.go
+++ b/aws_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/aws_test.go
+++ b/aws_test.go
@@ -12,8 +12,8 @@ func TestSendEmail(t *testing.T) {
 
 	sender := "sender@email.org"
 	recipient := "recipient@email.org"
-	subject := "ign-go AWS SES test"
-	body := "Hello from ign-go!"
+	subject := "gz-go AWS SES test"
+	body := "Hello from gz-go!"
 
 	err := SendEmail(sender, recipient, subject, body)
 	assert.Error(t, err, "Should not be able to send email through AWS SES")

--- a/database/gorm/gorm.go
+++ b/database/gorm/gorm.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"errors"
+	"github.com/gazebo-web/gz-go/v6"
 	"github.com/jinzhu/gorm"
 	"log"
 )
@@ -18,11 +19,11 @@ var (
 // * IGN_DB_PASSWORD Password to connect to the DBMS with.
 // * IGN_DB_NAME Name of the database to connect to.
 // * IGN_DB_MAX_OPEN_CONNS - (Optional) You run the risk of getting a 'too many connections' error if this is not set.
-func getDBConfigFromEnvVars() (*ign.DatabaseConfig, error) {
+func getDBConfigFromEnvVars() (*gz.DatabaseConfig, error) {
 	// Get the db config
-	var dbConfig ign.DatabaseConfig
+	var dbConfig gz.DatabaseConfig
 	var err error
-	dbConfig, err = ign.NewDatabaseConfigFromEnvVars()
+	dbConfig, err = gz.NewDatabaseConfigFromEnvVars()
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +43,7 @@ func GetDBFromEnvVars() (*gorm.DB, error) {
 	}
 
 	// Connect to the db
-	db, err := ign.InitDbWithCfg(dbConfig)
+	db, err := gz.InitDbWithCfg(dbConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,7 @@ func GetTestDBFromEnvVars() (*gorm.DB, error) {
 	dbConfig.Name += "_test"
 
 	// Connect to the db
-	db, err := ign.InitDbWithCfg(dbConfig)
+	db, err := gz.InitDbWithCfg(dbConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/database_test.go
+++ b/database_test.go
@@ -1,11 +1,11 @@
-package ign
+package gz
 
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-/////////////////////////////////////////////////
+// ///////////////////////////////////////////////
 // Test a bad connection to the database
 func TestBadDatabase(t *testing.T) {
 	var server Server

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"fmt"

--- a/ip_finder.go
+++ b/ip_finder.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 // Code originally taken from
 // https://husobee.github.io/golang/ip-address/2015/12/17/remote-ip-go.html
@@ -71,9 +71,9 @@ func isPrivateSubnet(ipAddress net.IP) bool {
 	return false
 }
 
-/////////////////////////////////////////////////
-/// getIPAddress searches, from right to left, for a valid IP address in a
-/// request.
+// ///////////////////////////////////////////////
+// / getIPAddress searches, from right to left, for a valid IP address in a
+// / request.
 func getIPAddress(r *http.Request) string {
 
 	// Search over possible headers.

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"context"

--- a/logger.go
+++ b/logger.go
@@ -213,7 +213,7 @@ func (l *ignLogger) Info(interfaces ...interface{}) {
 // string
 // map[string]interface{}
 // int
-// ign.ErrMsg
+// gz.ErrMsg
 func (l *ignLogger) Warning(interfaces ...interface{}) {
 	if l.verbosity < VerbosityWarning {
 		return
@@ -281,7 +281,7 @@ func (l *ignLogger) shouldSendToRollbar(msg []interface{}) bool {
 		return false
 	}
 
-	// Lastly, check if the rollbar msg includes an ign.ErrMsg. If yes, then check for
+	// Lastly, check if the rollbar msg includes an gz.ErrMsg. If yes, then check for
 	// blacklisted error codes.
 	if len(msg) > 0 {
 		el := msg[len(msg)-1]

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 // Import this file's dependencies
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"log"

--- a/monitoring_prometheus_test.go
+++ b/monitoring_prometheus_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"github.com/gazebo-web/gz-go/v6/monitoring"

--- a/pagination.go
+++ b/pagination.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"fmt"

--- a/queue.go
+++ b/queue.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"sync"

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"fmt"
@@ -65,6 +65,7 @@ func (suite *QueueTestSuite) TestEnqueueWaitForNextElementSingleGR() {
 // TestEnqueueLenMultipleGR enqueues elements concurrently
 //
 // Detailed steps:
+//
 //	1 - Enqueue totalGRs concurrently (from totalGRs different GRs)
 //	2 - Verifies the len, it should be equal to totalGRs
 //	3 - Verifies that all elements from 0 to totalGRs were enqueued
@@ -239,6 +240,7 @@ func (suite *QueueTestSuite) TestRemoveNotFound() {
 // TestRemoveMultipleGRs removes elements concurrently.
 //
 // Detailed steps:
+//
 //	1 - Enqueues totalElementsToEnqueue consecutive elements (0, 1, 2, 3, ... totalElementsToEnqueue - 1)
 //	2 - Hits queue.Remove(1) concurrently from totalElementsToRemove different GRs
 //	3 - Verifies the final len == totalElementsToEnqueue - totalElementsToRemove
@@ -312,6 +314,7 @@ func (suite *QueueTestSuite) TestDequeueSingleGR() {
 // TestDequeueMultipleGRs dequeues elements concurrently
 //
 // Detailed steps:
+//
 //	1 - Enqueues totalElementsToEnqueue consecutive integers
 //	2 - Dequeues totalElementsToDequeue concurrently from totalElementsToDequeue GRs
 //	3 - Verifies the final len, should be equal to totalElementsToEnqueue - totalElementsToDequeue

--- a/repository.go
+++ b/repository.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 // Repository represents a set of methods of a generic repository.
 // It is based in the Repository pattern, and allows to a system to change the underlying data structure

--- a/route_types.go
+++ b/route_types.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"net/http"

--- a/router.go
+++ b/router.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"encoding/json"

--- a/router_middleware.go
+++ b/router_middleware.go
@@ -122,8 +122,8 @@ func dbTransactionWrapper(handler HandlerWithResult) basicHandlerWithResult {
 	}
 }
 
-// handlerToHandlerWithResult converts an ign.Handler to an
-// ign.HandlerWithResult.
+// handlerToHandlerWithResult converts an gz.Handler to an
+// gz.HandlerWithResult.
 func handlerToHandlerWithResult(handler Handler) HandlerWithResult {
 	return func(tx *gorm.DB, w http.ResponseWriter, r *http.Request) (interface{}, *ErrMsg) {
 		err := handler(tx, w, r)

--- a/router_middleware.go
+++ b/router_middleware.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"encoding/json"
@@ -352,7 +352,7 @@ func getRequestID(r *http.Request) string {
 	return reqID
 }
 
-/////////////////////////////////////////////////
+// ///////////////////////////////////////////////
 // logger creates a middleware used to output HTTP requests.
 func logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -378,7 +378,7 @@ func logger(inner http.Handler, name string) http.Handler {
 	})
 }
 
-/////////////////////////////////////////////////
+// ///////////////////////////////////////////////
 // newGaEventTracking creates a new middleware to send events to Google Analytics.
 // Events will be automatically created using route information.
 // This middleware requires IGN_GA_TRACKING_ID and IGN_GA_APP_NAME

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"github.com/gazebo-web/gz-go/v6"
 	sch "gitlab.com/ignitionrobotics/web/scheduler"
 	"sync"
 	"time"
@@ -22,10 +23,10 @@ var once sync.Once
 var scheduler *Scheduler
 
 // initializeScheduler instantiate the singleton
-func initializeScheduler() *ign.ErrMsg {
+func initializeScheduler() *gz.ErrMsg {
 	s, err := sch.NewScheduler(1000)
 	if err != nil {
-		return ign.NewErrorMessage(ign.ErrorScheduler)
+		return gz.NewErrorMessage(gz.ErrorScheduler)
 	}
 	scheduler = &Scheduler{
 		Scheduler: s,

--- a/testhelpers/router_test_helpers.go
+++ b/testhelpers/router_test_helpers.go
@@ -1,4 +1,4 @@
-package igntest
+package gztest
 
 // Important note: functions in this module should not include
 // references to parent package 'ign', to avoid circular dependencies.

--- a/testhelpers/test_helpers.go
+++ b/testhelpers/test_helpers.go
@@ -1,4 +1,4 @@
-package igntest
+package gztest
 
 // Important note: functions in this module should NOT include
 // references to parent package 'ign', to avoid circular dependencies.

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 // Int returns a pointer to the int value passed in.
 func Int(v int) *int {

--- a/types_test.go
+++ b/types_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/utility.go
+++ b/utility.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"archive/zip"

--- a/utility_test.go
+++ b/utility_test.go
@@ -1,4 +1,4 @@
-package ign
+package gz
 
 import (
 	"errors"


### PR DESCRIPTION
Due to the migration to GitHub, we also renamed the package to `gz-go`. It makes sense for it to be called `gz` instead of `ign`. This PR changes the package definition to `gz`.

This was tested on a testing branch in a private repository and it works as expected.

- CI will be introduced in a future PR.
- We haven't changed the env vars prefix from `IGN_` to `GZ_`.