### PR TITLE
Fix scheduler import

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"github.com/gazebo-web/gz-go/v6"
 	sch "gitlab.com/ignitionrobotics/web/scheduler"
 	"sync"
 	"time"


### PR DESCRIPTION
This PR fixes the import of `ign` in the `scheduler` package. Related to #4 but for a different package.