### PR TITLE
Limit the lifespan of Presigned URLs in AWS S3 implementations

### DIFF
--- a/storage/s3_v1.go
+++ b/storage/s3_v1.go
@@ -74,7 +74,7 @@ func NewS3v1(client *s3api.S3, uploader *s3manager.Uploader, bucket string) Stor
 		client:   client,
 		uploader: uploader,
 		bucket:   bucket,
-		duration: 60 * time.Minute,
+		duration: 5 * time.Minute,
 	}
 }
 

--- a/storage/s3_v2.go
+++ b/storage/s3_v2.go
@@ -72,7 +72,7 @@ func NewS3v2(client *s3api.Client, bucket string) Storage {
 		client:   client,
 		presign:  s3api.NewPresignClient(client),
 		bucket:   bucket,
-		duration: 60 * time.Minute,
+		duration: 5 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
This PR adds a missing change on the AWS S3 implementation that limits the lifespan of Presigned URLs.