### PR TITLE
Add AuthFunc for enabling authentication gRPC interceptors

### DIFF
--- a/middleware/auth_bearer.go
+++ b/middleware/auth_bearer.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"context"
+	"github.com/gazebo-web/auth/pkg/authentication"
+	"github.com/golang-jwt/jwt/v5/request"
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// BearerToken returns a Middleware for authenticating users using Bearer Tokens in JWT format.
+func BearerToken(authentication authentication.Authentication) Middleware {
+	return newTokenMiddleware(authentication.VerifyJWT, request.BearerExtractor{})
+}
+
+// BearerAuthFuncGRPC returns a new grpc_auth.AuthFunc to use with the gazebo-web authentication library.
+//
+// The passed in context.Context will contain the gRPC metadata.MD object (for header-based authentication) and
+// the peer.Peer information that can contain transport-based credentials (e.g. `credentials.AuthInfo`).
+//
+//	auth := authentication.New[...]()
+//
+//	srv := grpc.NewServer(
+//		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth))),
+//		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth))),
+//	)
+func BearerAuthFuncGRPC(auth authentication.Authentication) grpc_auth.AuthFunc {
+	return func(ctx context.Context) (context.Context, error) {
+		token, err := grpc_auth.AuthFromMD(ctx, "bearer")
+		if err != nil {
+			return nil, err
+		}
+		if err := auth.VerifyJWT(ctx, token); err != nil {
+			return nil, status.Error(codes.Unauthenticated, err.Error())
+		}
+		return ctx, nil
+	}
+}

--- a/middleware/auth_bearer_test.go
+++ b/middleware/auth_bearer_test.go
@@ -152,8 +152,8 @@ func TestAuthFuncGRPC(t *testing.T) {
 		InterceptorTestSuite: &grpc_test.InterceptorTestSuite{
 			TestService: auth,
 			ServerOpts: []grpc.ServerOption{
-				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(AuthFuncGRPC(auth))),
-				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(AuthFuncGRPC(auth))),
+				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth))),
+				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth))),
 			},
 		},
 	}

--- a/middleware/auth_bearer_test.go
+++ b/middleware/auth_bearer_test.go
@@ -211,7 +211,6 @@ type testAuthService struct {
 	mock.Mock
 }
 
-// Ping can be called by client without being authenticated by exampleAuthFunc as AuthFuncOverride is called instead.
 func (s *testAuthService) Ping(_ context.Context, _ *grpc_testproto.PingRequest) (*grpc_testproto.PingResponse, error) {
 	return &grpc_testproto.PingResponse{}, nil
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -52,6 +52,16 @@ func newTokenMiddleware(verify authentication.TokenAuthentication, extractors ..
 }
 
 // AuthFuncGRPC returns a new grpc_auth.AuthFunc to use with the gazebo-web authentication library.
+//
+// The passed in context.Context will contain the gRPC metadata.MD object (for header-based authentication) and
+// the peer.Peer information that can contain transport-based credentials (e.g. `credentials.AuthInfo`).
+//
+//	auth := authentication.New[...]()
+//
+//	srv := grpc.NewServer(
+//		grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(AuthFuncGRPC(auth))),
+//		grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(AuthFuncGRPC(auth))),
+//	)
 func AuthFuncGRPC(auth authentication.Authentication) grpc_auth.AuthFunc {
 	return func(ctx context.Context) (context.Context, error) {
 		token, err := grpc_auth.AuthFromMD(ctx, "bearer")


### PR DESCRIPTION
# Context
gRPC interceptors are mechanism that enables gRPC servers to intercept incoming RPC invocations.

The [grpc-ecosystem](https://github.com/grpc-ecosystem) organization provides a [middleware](https://github.com/grpc-ecosystem/go-grpc-middleware) module that includes an [auth](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v1/auth) package. The `auth` package provides the following interceptors:

```go
func UnaryServerInterceptor(authFunc AuthFunc) grpc.UnaryServerInterceptor {
  // ...
}
```

```go
func StreamServerInterceptor(authFunc AuthFunc) grpc.StreamServerInterceptor {
  // ...
}
```

From their documentation:
```go
// AuthFunc is the pluggable function that performs authentication.
//
// The passed in `Context` will contain the gRPC metadata.MD object (for header-based authentication) and
// the peer.Peer information that can contain transport-based credentials (e.g. `credentials.AuthInfo`).
//
// The returned context will be propagated to handlers, allowing user changes to `Context`. However,
// please make sure that the `Context` returned is a child `Context` of the one passed in.
//
// If error is returned, its `grpc.Code()` will be returned to the user as well as the verbatim message.
// Please make sure you use `codes.Unauthenticated` (lacking auth) and `codes.PermissionDenied`
// (authed, but lacking perms) appropriately.
type AuthFunc func(ctx context.Context) (context.Context, error)
```

# Changes
This PR creates an implementation for generating `AuthFunc` using the `authentication` library: https://github.com/gazebo-web/auth