### PR TITLE
Move Repository SQL implementation into own package

### DIFF
--- a/repository/model.go
+++ b/repository/model.go
@@ -1,9 +1,5 @@
 package repository
 
-import (
-	"time"
-)
-
 // Model represents a generic entity. A Model is part of the domain layer and is  persisted by a certain Repository.
 type Model interface {
 	// TableName returns the table/collection name for a certain model.
@@ -12,24 +8,4 @@ type Model interface {
 	// It returns the ID of the model that has been persisted. It returns 0 if no value has been defined.
 	// For SQL environments, this would be the primary key.
 	GetID() uint
-}
-
-// ModelSQL implements Model for SQL backends.
-// It provides a set of common generic fields and operations that partially implement the repository.Model interface.
-// To use it, embed it in your application-specific repository.Model implementation.
-type ModelSQL struct {
-	// ID contains the primary key identifier.
-	ID uint `gorm:"primary_key"`
-	// CreatedAt contains the date and time at which this model has been persisted.
-	CreatedAt time.Time `json:"created_at"`
-	// UpdatedAt contains the last date and time when this model has been updated.
-	UpdatedAt time.Time `json:"updated_at"`
-	// DeletedAt is used to implement soft record deletion. If set, the record will be considered
-	// as deleted.
-	DeletedAt *time.Time `json:"deleted_at" sql:"index"`
-}
-
-// GetID returns the unique identifier for this Model.
-func (m ModelSQL) GetID() uint {
-	return m.ID
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -29,7 +29,7 @@ type Repository interface {
 	// Create inserts a single entry.
 	// entity: The entry to insert.
 	Create(entity Model) (Model, error)
-	// CreateBulk is a bulk operation to create multiple entries with a single operation.
+	// CreateBulk creates multiple entries with a single operation.
 	// entities: should be a slice of a Model implementation.
 	CreateBulk(entities []Model) ([]Model, error)
 	// Find filters entries and stores filtered entries in output.

--- a/repository/sql/model.go
+++ b/repository/sql/model.go
@@ -1,0 +1,23 @@
+package sql
+
+import "time"
+
+// Model implements the repository.Model interface for SQL backends.
+// It provides a set of common generic fields and operations that partially implement the repository.Model interface.
+// To use it, embed it in your application-specific repository.Model implementation.
+type Model struct {
+	// ID contains the primary key identifier.
+	ID uint `gorm:"primary_key"`
+	// CreatedAt contains the date and time at which this model has been persisted.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt contains the last date and time when this model has been updated.
+	UpdatedAt time.Time `json:"updated_at"`
+	// DeletedAt is used to implement soft record deletion. If set, the record will be considered
+	// as deleted.
+	DeletedAt *time.Time `json:"deleted_at" sql:"index"`
+}
+
+// GetID returns the unique identifier for this Model.
+func (m Model) GetID() uint {
+	return m.ID
+}

--- a/repository/sql/options.go
+++ b/repository/sql/options.go
@@ -1,38 +1,38 @@
-package repository
+package sql
 
 import (
 	"fmt"
+	"github.com/gazebo-web/gz-go/v7/repository"
 	"github.com/jinzhu/gorm"
 	"strings"
 )
 
-// SQLOption is a SQL-specific Repository Option implementation.
+// Option is a SQL-specific repository.Option implementation.
 // It is used to configure SQL repository operations.
-// TODO This should be extracted into its own package to avoid colliding with other implementations
-type SQLOption func(r *gorm.DB)
+type Option func(r *gorm.DB)
 
-func (l SQLOption) IsOption() {}
+func (l Option) IsOption() {}
 
 // Fields defines fields to return.
-// Passing this Option to a Repository operation overwrites any previous GroupBy options passed.
-func Fields(fields ...string) Option {
-	return SQLOption(func(q *gorm.DB) {
+// Passing this Option to a Repository operation overwrites any previous Fields options passed.
+func Fields(fields ...string) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Select(strings.Join(fields, ","))
 	})
 }
 
 // Where filters results based on passed conditions.
 // Multiple Filter options can be passed to a single Repository operation. They are logically ANDed together.
-func Where(template string, values ...interface{}) Option {
-	return SQLOption(func(q *gorm.DB) {
+func Where(template string, values ...interface{}) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Where(template, values...)
 	})
 }
 
 // MaxResults defines the maximum number of results for an operation that can return multiple results.
 // Passing this Option to a Repository operation overwrites any previous MaxResults options passed.
-func MaxResults(n int) Option {
-	return SQLOption(func(q *gorm.DB) {
+func MaxResults(n int) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Limit(n)
 	})
 }
@@ -40,16 +40,16 @@ func MaxResults(n int) Option {
 // Offset defines a number of results to skip before starting to capture values to return.
 // This Option will be ignored if the MaxResults Option is not present.
 // Passing this Option to a Repository operation overwrites any previous Offset options passed.
-func Offset(offset int) Option {
-	return SQLOption(func(q *gorm.DB) {
+func Offset(offset int) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Offset(offset)
 	})
 }
 
 // GroupBy groups results based field values.
 // Passing this Option to a Repository operation overwrites any previous GroupBy options passed.
-func GroupBy(fields ...string) Option {
-	return SQLOption(func(q *gorm.DB) {
+func GroupBy(fields ...string) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Group(strings.Join(fields, ","))
 	})
 }
@@ -71,8 +71,8 @@ func Descending(field string) OrderByField {
 // Use the Ascending and Descending functions to pass orders to this Option.
 // In situations with multiple orders, they are applied in sequence.
 // Multiple OrderBy options can be passed to a single Repository operation. They are appended to any previous orders.
-func OrderBy(orders ...OrderByField) Option {
-	return SQLOption(func(q *gorm.DB) {
+func OrderBy(orders ...OrderByField) repository.Option {
+	return Option(func(q *gorm.DB) {
 		for _, order := range orders {
 			*q = *q.Order(string(order))
 		}
@@ -83,8 +83,8 @@ func OrderBy(orders ...OrderByField) Option {
 // The field parameter must match the model field name exactly (case-sensitive).
 // An optional filter composed of a template and any number of values can be passed to filter preloaded results.
 // Multiple Preload options can be passed to a single Repository operation. They are appended to any previous preloads.
-func Preload(field string, filter ...interface{}) Option {
-	return SQLOption(func(q *gorm.DB) {
+func Preload(field string, filter ...interface{}) repository.Option {
+	return Option(func(q *gorm.DB) {
 		*q = *q.Preload(field, filter...)
 	})
 }

--- a/repository/sql/options_test.go
+++ b/repository/sql/options_test.go
@@ -1,15 +1,16 @@
-package repository
+package sql
 
 import (
 	"fmt"
 	utilsgorm "github.com/gazebo-web/gz-go/v7/database/gorm"
+	"github.com/gazebo-web/gz-go/v7/repository"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
 
 type SQLOptionsReferenceModel struct {
-	ModelSQL
+	Model
 	Value       int `json:"value"`
 	ReferenceID *uint
 	Reference   *SQLOptionsReferenceModel
@@ -20,7 +21,7 @@ func (t SQLOptionsReferenceModel) TableName() string {
 }
 
 type SQLOptionsTestModel struct {
-	ModelSQL
+	Model
 	Name         string `json:"name"`
 	Value        int    `json:"value"`
 	Even         bool   `json:"even"`
@@ -48,7 +49,7 @@ func TestSQLOptions(t *testing.T) {
 type SQLOptionsTestSuite struct {
 	suite.Suite
 	db         *gorm.DB
-	repository Repository
+	repository repository.Repository
 	models     []interface{}
 }
 
@@ -102,7 +103,7 @@ func (s *SQLOptionsTestSuite) TearDownSuite() {
 }
 
 func (s *SQLOptionsTestSuite) TestSQLOptionImplementsOption() {
-	s.Assert().Implements((*Option)(nil), new(SQLOption))
+	s.Assert().Implements((*Option)(nil), new(Option))
 }
 
 func (s *SQLOptionsTestSuite) getValues(values []*SQLOptionsTestModel) (out []int) {
@@ -160,7 +161,7 @@ func (s *SQLOptionsTestSuite) TestFindOffsetOption() {
 	s.Assert().EqualValues([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, s.getValues(out))
 }
 
-//func (s *SQLOptionsTestSuite) TestFindSelectAndGroupByOptions() {
+// func (s *SQLOptionsTestSuite) TestFindSelectAndGroupByOptions() {
 //	var out []*SQLOptionsTestModel
 //
 //	// GroupBy fails if unaggregated fields are returned
@@ -173,7 +174,7 @@ func (s *SQLOptionsTestSuite) TestFindOffsetOption() {
 //	// Multiple field group
 //	s.Assert().NoError(s.repository.Find(&out, Fields("SUM(value) value"), GroupBy("even", "lte5")))
 //	s.Assert().EqualValues([]int{1 + 3 + 5, 2 + 4, 6 + 8 + 10, 7 + 9}, s.getValues(out))
-//}
+// }
 
 func (s *SQLOptionsTestSuite) TestFindPreloadOption() {
 	var out []*SQLOptionsTestModel

--- a/repository/sql/options_test.go
+++ b/repository/sql/options_test.go
@@ -103,7 +103,7 @@ func (s *SQLOptionsTestSuite) TearDownSuite() {
 }
 
 func (s *SQLOptionsTestSuite) TestSQLOptionImplementsOption() {
-	s.Assert().Implements((*Option)(nil), new(Option))
+	s.Assert().Implements((*repository.Option)(nil), new(Option))
 }
 
 func (s *SQLOptionsTestSuite) getValues(values []*SQLOptionsTestModel) (out []int) {

--- a/repository/sql/repository_test.go
+++ b/repository/sql/repository_test.go
@@ -1,7 +1,8 @@
-package repository
+package sql
 
 import (
 	utilsgorm "github.com/gazebo-web/gz-go/v7/database/gorm"
+	"github.com/gazebo-web/gz-go/v7/repository"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -14,11 +15,11 @@ func TestRepository(t *testing.T) {
 type RepositoryTestSuite struct {
 	suite.Suite
 	db         *gorm.DB
-	Repository Repository
+	Repository repository.Repository
 }
 
 type Test struct {
-	ModelSQL
+	Model
 	Name  string `json:"name"`
 	Value int    `json:"value"`
 }
@@ -57,7 +58,7 @@ func (suite *RepositoryTestSuite) SetupTest() {
 		Value: 3,
 	}
 
-	res, err := suite.Repository.CreateBulk([]Model{test1, test2, test3})
+	res, err := suite.Repository.CreateBulk([]repository.Model{test1, test2, test3})
 	suite.Require().NoError(err)
 	suite.Require().Len(res, 3)
 }
@@ -68,13 +69,13 @@ func (suite *RepositoryTestSuite) TearDownSuite() {
 }
 
 func (suite *RepositoryTestSuite) TestImplementsInterface() {
-	var expected *Repository
-	suite.Assert().Implements(expected, new(repositorySQL))
+	var expected *repository.Repository
+	suite.Assert().Implements(expected, new(repositoryGorm))
 }
 
 func (suite *RepositoryTestSuite) TestCreateOne() {
 	// Creating one record should not fail.
-	res, err := suite.Repository.CreateBulk([]Model{&Test{
+	res, err := suite.Repository.CreateBulk([]repository.Model{&Test{
 		Name:  "test",
 		Value: 999,
 	}})
@@ -89,7 +90,7 @@ func (suite *RepositoryTestSuite) TestCreateOne() {
 
 func (suite *RepositoryTestSuite) TestCreateMultiple() {
 	// Creating multiple records should not fail
-	res, err := suite.Repository.CreateBulk([]Model{
+	res, err := suite.Repository.CreateBulk([]repository.Model{
 		&Test{
 			Name:  "test",
 			Value: 999,
@@ -127,10 +128,10 @@ func (suite *RepositoryTestSuite) TestFindOne() {
 	var t Test
 
 	// Finding one should not fail.
-	suite.Assert().NoError(suite.Repository.FindOne(&t, Filter{
+	suite.Assert().NoError(suite.Repository.FindOne(&t, repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test1"},
-	}, Filter{
+	}, repository.Filter{
 		Template: "value = ?",
 		Values:   []interface{}{1},
 	}))
@@ -140,7 +141,7 @@ func (suite *RepositoryTestSuite) TestFindOne() {
 }
 
 func (suite *RepositoryTestSuite) TestUpdate() {
-	filter := Filter{
+	filter := repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test1"},
 	}
@@ -154,7 +155,7 @@ func (suite *RepositoryTestSuite) TestUpdate() {
 	suite.Assert().Error(suite.Repository.FindOne(&t, filter))
 
 	// Finding the correct record should not fail.
-	suite.Assert().NoError(suite.Repository.FindOne(&t, Filter{
+	suite.Assert().NoError(suite.Repository.FindOne(&t, repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test111"},
 	}))
@@ -165,7 +166,7 @@ func (suite *RepositoryTestSuite) TestUpdate() {
 }
 
 func (suite *RepositoryTestSuite) TestDelete() {
-	filter := Filter{
+	filter := repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test1"},
 	}
@@ -183,7 +184,7 @@ func (suite *RepositoryTestSuite) TestDelete() {
 
 func (suite *RepositoryTestSuite) TestFirstOrCreate() {
 	var test Test
-	suite.Require().NoError(suite.Repository.FirstOrCreate(&test, Filter{
+	suite.Require().NoError(suite.Repository.FirstOrCreate(&test, repository.Filter{
 		Template: "value = ?",
 		Values:   []interface{}{1},
 	}))
@@ -196,7 +197,7 @@ func (suite *RepositoryTestSuite) TestFirstOrCreate() {
 		Value: 4,
 	}
 
-	suite.Require().NoError(suite.Repository.FirstOrCreate(&test, Filter{
+	suite.Require().NoError(suite.Repository.FirstOrCreate(&test, repository.Filter{
 		Template: "value = ?",
 		Values:   []interface{}{4},
 	}))
@@ -215,7 +216,7 @@ func (suite *RepositoryTestSuite) TestLast() {
 	suite.Require().NoError(err)
 
 	var out Test
-	err = suite.Repository.Last(&out, Filter{
+	err = suite.Repository.Last(&out, repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test3"},
 	})
@@ -225,14 +226,14 @@ func (suite *RepositoryTestSuite) TestLast() {
 }
 
 func (suite *RepositoryTestSuite) TestCount() {
-	count, err := suite.Repository.Count(Filter{
+	count, err := suite.Repository.Count(repository.Filter{
 		Template: "name = ?",
 		Values:   []interface{}{"Test3"},
 	})
 	suite.Assert().NoError(err)
 	suite.Assert().Equal(uint64(1), count)
 
-	count, err = suite.Repository.Count(Filter{
+	count, err = suite.Repository.Count(repository.Filter{
 		Template: "name LIKE ?",
 		Values:   []interface{}{"Test%"},
 	})


### PR DESCRIPTION
Closes #21.

The `repository` package provides a generic `Repository` interface and a number of implementations for it. Up until this point, there had only ever been a SQL implementation, and it was defined at the `repository` package level. Because both interface and implementations are all contained under a single namespace, other implementations may run into namespace collision issues with the SQL implementation.

This PR moves the SQL implementation into its own package to avoid collision issues.

The new packages structure looks like this:
```
repository    Contains generic definitions such as the `Repository` interface and related types.
└── sql       SQL Repository implementation.
```

New implementation should be defined in their own package inside the `repository` package.