### PR TITLE
Add ParsePageToken

### DIFF
--- a/pagination/helpers.go
+++ b/pagination/helpers.go
@@ -3,6 +3,7 @@ package pagination
 import (
 	"encoding"
 	"encoding/base64"
+	"time"
 )
 
 // PageSizeGetter holds a method to return the amount of pages requested by users when listing items in an API call.
@@ -51,4 +52,18 @@ func NewPageToken(input encoding.TextMarshaler) string {
 	dst := make([]byte, base64.StdEncoding.EncodedLen(len(src)))
 	base64.StdEncoding.Encode(dst, src)
 	return string(dst)
+}
+
+// ParsePageToken converts the given token and returns a valid time.Time.
+// The token provided is usually the value used in cursor-based pagination.
+func ParsePageToken(token string) (time.Time, error) {
+	value, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return time.Time{}, err
+	}
+	result, err := time.Parse(time.RFC3339, string(value))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return result, err
 }

--- a/pagination/helpers.go
+++ b/pagination/helpers.go
@@ -54,9 +54,9 @@ func NewPageToken(input encoding.TextMarshaler) string {
 	return string(dst)
 }
 
-// ParsePageToken converts the given token and returns a valid time.Time.
+// ParsePageTokenToTime converts the given token and returns a valid time.Time.
 // The token provided is usually the value used in cursor-based pagination.
-func ParsePageToken(token string) (time.Time, error) {
+func ParsePageTokenToTime(token string) (time.Time, error) {
 	value, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
 		return time.Time{}, err

--- a/pagination/helpers_test.go
+++ b/pagination/helpers_test.go
@@ -86,7 +86,7 @@ func TestGeneratePageToken(t *testing.T) {
 	assert.True(t, result.Equal(updatedAt))
 }
 
-func TestParsePageToken(t *testing.T) {
+func TestParsePageTokenToTime(t *testing.T) {
 	// No token provided
 	_, err := ParsePageTokenToTime("")
 	assert.Error(t, err)

--- a/pagination/helpers_test.go
+++ b/pagination/helpers_test.go
@@ -73,3 +73,21 @@ func TestGeneratePageToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.Equal(updatedAt))
 }
+
+func TestParsePageToken(t *testing.T) {
+	// No token provided
+	_, err := ParsePageToken("")
+	assert.Error(t, err)
+
+	// Not a date
+	_, err = ParsePageToken("12345")
+	assert.Error(t, err)
+
+	// A valid time.Time should be correctly parsed into a time.Time when using ParsePageToken.
+	updatedAt := time.Now()
+	token := NewPageToken(updatedAt)
+
+	result, err := ParsePageToken(token)
+	require.NoError(t, err)
+	assert.True(t, result.Equal(updatedAt))
+}

--- a/pagination/helpers_test.go
+++ b/pagination/helpers_test.go
@@ -76,18 +76,18 @@ func TestGeneratePageToken(t *testing.T) {
 
 func TestParsePageToken(t *testing.T) {
 	// No token provided
-	_, err := ParsePageToken("")
+	_, err := ParsePageTokenToTime("")
 	assert.Error(t, err)
 
 	// Not a date
-	_, err = ParsePageToken("12345")
+	_, err = ParsePageTokenToTime("12345")
 	assert.Error(t, err)
 
-	// A valid time.Time should be correctly parsed into a time.Time when using ParsePageToken.
+	// A valid time.Time should be correctly parsed into a time.Time when using ParsePageTokenToTime.
 	updatedAt := time.Now()
 	token := NewPageToken(updatedAt)
 
-	result, err := ParsePageToken(token)
+	result, err := ParsePageTokenToTime(token)
 	require.NoError(t, err)
 	assert.True(t, result.Equal(updatedAt))
 }


### PR DESCRIPTION
This PR adds another helper function for parsing a `token` into a timestamp.