### PR TITLE
Add StartAt option

### DIFF
--- a/repository/firestore/firestore_test.go
+++ b/repository/firestore/firestore_test.go
@@ -147,11 +147,21 @@ func (suite *FirestoreRepositoryTestSuite) TestFind_Where() {
 	suite.Assert().Equal(1, found[0].Value)
 }
 
-func (suite *FirestoreRepositoryTestSuite) TestFind_Pagination_PageWithCursor() {
+func (suite *FirestoreRepositoryTestSuite) TestFind_Pagination_PageWithStartAfter() {
 	suite.setupMockData()
 
 	var found []Test
 	suite.Require().NoError(suite.repository.Find(&found, OrderBy(Descending("Value")), StartAfter(3), MaxResults(100)))
+	suite.Assert().Len(found, 2)
+	suite.Assert().Equal(2, found[0].Value)
+	suite.Assert().Equal(1, found[1].Value)
+}
+
+func (suite *FirestoreRepositoryTestSuite) TestFind_Pagination_PageWithStartAt() {
+	suite.setupMockData()
+
+	var found []Test
+	suite.Require().NoError(suite.repository.Find(&found, OrderBy(Descending("Value")), StartAt(2), MaxResults(100)))
 	suite.Assert().Len(found, 2)
 	suite.Assert().Equal(2, found[0].Value)
 	suite.Assert().Equal(1, found[1].Value)

--- a/repository/firestore/options.go
+++ b/repository/firestore/options.go
@@ -102,6 +102,6 @@ func StartAfter(fieldValues ...any) repository.Option {
 // Calling StartAfter overrides a previous call to StartAfter.
 func StartAt(fieldValues ...any) repository.Option {
 	return Option(func(q *firestore.Query) {
-		*q = q.StartAfter(fieldValues...)
+		*q = q.StartAt(fieldValues...)
 	})
 }

--- a/repository/firestore/options.go
+++ b/repository/firestore/options.go
@@ -88,3 +88,20 @@ func StartAfter(fieldValues ...any) repository.Option {
 		*q = q.StartAfter(fieldValues...)
 	})
 }
+
+// StartAt initializes a new option that specifies that results should start at
+// document with the given field values.
+//
+// StartAt should be called with one field value for each OrderBy clause,
+// in the order that they appear. For example, in
+//
+//	Repository.Find(&list, OrderBy(Descending("Value"), Ascending("Name")), StartAt(1, "Test"))
+//
+// list will begin at the first document where Value = <1> + 1.
+//
+// Calling StartAfter overrides a previous call to StartAfter.
+func StartAt(fieldValues ...any) repository.Option {
+	return Option(func(q *firestore.Query) {
+		*q = q.StartAfter(fieldValues...)
+	})
+}


### PR DESCRIPTION
This PR adds the `StartAt` option to enable pagination starting from a certain element in a collection.