### PR TITLE
Modeler interface

### DIFF
--- a/repository/firestore/firestore_test.go
+++ b/repository/firestore/firestore_test.go
@@ -327,6 +327,6 @@ type Test struct {
 	Value int    `json:"value"`
 }
 
-func (t Test) TableName() string {
+func (Test) TableName() string {
 	return "test"
 }

--- a/repository/firestore/model.go
+++ b/repository/firestore/model.go
@@ -1,18 +1,53 @@
 package firestore
 
-import "time"
+import (
+	"github.com/gazebo-web/gz-go/v7/repository"
+	"time"
+)
+
+// Modeler is a specific repository.Model interface for Firestore repositories. It includes a set of methods to
+// load firestore.DocumentSnapshot metadata into Model.
+type Modeler interface {
+	repository.Model
+	// SetUID sets the given UID as the document identifier.
+	SetUID(uid string) Modeler
+	// SetCreatedAt sets the given createdAt value as the creation timestamp.
+	SetCreatedAt(createdAt time.Time) Modeler
+	// SetUpdatedAt sets the given updatedAt value as the last update timestamp.
+	SetUpdatedAt(updatedAt time.Time) Modeler
+}
 
 // Model implements the repository.Model interface for firestore.
 // It provides a set of common generic fields and operations that partially implement the repository.Model interface.
 // To use it, embed it in your application-specific repository.Model implementation.
 type Model struct {
+	// ID contains the Document ID.
+	ID string
 	// CreatedAt contains the date and time at which this model has been persisted.
-	CreatedAt time.Time `firestore:"created_at"`
+	CreatedAt time.Time `firestore:"-"`
 	// UpdatedAt contains the last date and time when this model has been updated.
-	UpdatedAt time.Time `firestore:"updated_at"`
+	UpdatedAt time.Time `firestore:"-"`
 }
 
-// GetID returns the unique identifier for this Model.
-func (m Model) GetID() uint {
-	return 0
+// TableName is included to fulfill the Modeler interface. Application should override this method on each model.
+func (m Model) TableName() string {
+	return "default"
+}
+
+// SetUID sets the given UID as the document identifier.
+func (m Model) SetUID(uid string) Modeler {
+	m.ID = uid
+	return m
+}
+
+// SetCreatedAt sets the given createdAt value as the timestamp when this document was created.
+func (m Model) SetCreatedAt(createdAt time.Time) Modeler {
+	m.CreatedAt = createdAt
+	return m
+}
+
+// SetUpdatedAt sets the given updatedAt value as the timestamp when this document was last updated.
+func (m Model) SetUpdatedAt(updatedAt time.Time) Modeler {
+	m.UpdatedAt = updatedAt
+	return m
 }

--- a/repository/model.go
+++ b/repository/model.go
@@ -4,8 +4,4 @@ package repository
 type Model interface {
 	// TableName returns the table/collection name for a certain model.
 	TableName() string
-	// GetID returns the unique identifier for this Model.
-	// It returns the ID of the model that has been persisted. It returns 0 if no value has been defined.
-	// For SQL environments, this would be the primary key.
-	GetID() uint
 }


### PR DESCRIPTION
This PR adds a new interface in the `firestore` package. It allows documents to load snapshot data into a Go struct by adding a few methods to set the `uid`, and the `created_at` and `updated_at` dates.