### PR TITLE
Add ParseURL

### DIFF
--- a/utility.go
+++ b/utility.go
@@ -411,12 +411,21 @@ func RemoveIfFound(path string) error {
 	return nil
 }
 
-// ValidateURL validates if a raw URL string is well-formed or not.
-func ValidateURL(raw string) error {
-	u, err := url.ParseRequestURI(raw)
+// ParseURL parses the given raw URL in string format to an url.URL.
+func ParseURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	err = ValidateURL(u)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// ValidateURL validates if the given URL is well-formed or not.
+func ValidateURL(u *url.URL) error {
 	if u.Scheme == "" && u.Host == "" {
 		return gzerrors.ErrInvalidURL
 	}

--- a/utility_test.go
+++ b/utility_test.go
@@ -59,9 +59,32 @@ func TestRemoveIfFound(t *testing.T) {
 	require.NoError(t, os.RemoveAll(path))
 }
 
-func TestValidateURL(t *testing.T) {
-	assert.Error(t, ValidateURL("wrong"))
-	assert.Error(t, ValidateURL("1234"))
-	assert.NoError(t, ValidateURL("http://localhost:3333"))
-	assert.NoError(t, ValidateURL("https://gazebosim.org"))
+func TestParseURL(t *testing.T) {
+	u, err := ParseURL("wrong")
+	assert.Error(t, err)
+	assert.Nil(t, u)
+
+	u, err = ParseURL("1234")
+	assert.Error(t, err)
+	assert.Nil(t, u)
+
+	u, err = ParseURL("http://localhost:3333")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+
+	u, err = ParseURL("https://gazebosim.org")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+
+	u, err = ParseURL("ws://gazebosim.org/simulations/123456")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+
+	u, err = ParseURL("wss://gazebosim.org/simulations/123456")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
+
+	u, err = ParseURL("s3://gazebosim.org/simulations/123456")
+	assert.NoError(t, err)
+	assert.NotNil(t, u)
 }


### PR DESCRIPTION
This PR avoids applications to parse the URL twice by adding a `ParseURL` function that does both parsing and validation.

The `ValidateURL` now accepts a `url.URL` argument instead of a raw string.