### PR TITLE
Add NewDateTime helper func

### DIFF
--- a/utility.go
+++ b/utility.go
@@ -436,9 +436,10 @@ func ValidateURL(u *url.URL) error {
 
 // NewDateTime initializes a new datetime.DateTime from the current time.Time.
 // It infers the datetime.DateTime's timezone from the current location.
-func NewDateTime(t time.Time) datetime.DateTime {
+// NOTE: datetime.DateTime is a protobuf message.
+func NewDateTime(t time.Time) *datetime.DateTime {
 	_, offset := t.Zone()
-	return datetime.DateTime{
+	return &datetime.DateTime{
 		Year:       int32(t.Year()),
 		Month:      int32(t.Month()),
 		Day:        int32(t.Day()),

--- a/utility.go
+++ b/utility.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	gzerrors "github.com/gazebo-web/gz-go/v8/errors"
+	"google.golang.org/genproto/googleapis/type/datetime"
+	"google.golang.org/protobuf/types/known/durationpb"
 	htmlTemplate "html/template"
 	"io"
 	"log"
@@ -430,4 +432,20 @@ func ValidateURL(u *url.URL) error {
 		return gzerrors.ErrInvalidURL
 	}
 	return nil
+}
+
+// NewDateTime initializes a new datetime.DateTime from the current time.Time.
+// It infers the datetime.DateTime's timezone from the current location.
+func NewDateTime(t time.Time) datetime.DateTime {
+	_, offset := t.Zone()
+	return datetime.DateTime{
+		Year:       int32(t.Year()),
+		Month:      int32(t.Month()),
+		Day:        int32(t.Day()),
+		Hours:      int32(t.Hour()),
+		Minutes:    int32(t.Minute()),
+		Seconds:    int32(t.Second()),
+		Nanos:      int32(t.Nanosecond()),
+		TimeOffset: &datetime.DateTime_UtcOffset{UtcOffset: durationpb.New(time.Duration(offset) * time.Second)},
+	}
 }

--- a/utility_test.go
+++ b/utility_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Tests for utility file
@@ -87,4 +88,22 @@ func TestParseURL(t *testing.T) {
 	u, err = ParseURL("s3://gazebosim.org/simulations/123456")
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
+}
+
+func TestNewDateTime(t *testing.T) {
+	now := time.Now()
+	date := NewDateTime(now)
+	assert.NotEmpty(t, date.GetTimeZone().String())
+	assert.Equal(t, now.Year(), int(date.GetYear()))
+	assert.Equal(t, int(now.Month()), int(date.GetMonth()))
+	assert.Equal(t, now.Day(), int(date.GetDay()))
+	assert.Equal(t, now.Hour(), int(date.GetHours()))
+	assert.Equal(t, now.Minute(), int(date.GetMinutes()))
+	assert.Equal(t, now.Second(), int(date.GetSeconds()))
+	assert.Equal(t, now.Nanosecond(), int(date.GetNanos()))
+	assert.NotNil(t, date.TimeOffset)
+
+	_, offset := now.Zone()
+	assert.Equal(t, time.Duration(offset)*time.Second, date.GetUtcOffset().AsDuration())
+	t.Log("Offset:", offset, "Got:", date.GetUtcOffset().AsDuration().String())
 }

--- a/utility_test.go
+++ b/utility_test.go
@@ -93,6 +93,7 @@ func TestParseURL(t *testing.T) {
 func TestNewDateTime(t *testing.T) {
 	now := time.Now()
 	date := NewDateTime(now)
+	require.NotNil(t, date)
 	assert.NotEmpty(t, date.GetTimeZone().String())
 	assert.Equal(t, now.Year(), int(date.GetYear()))
 	assert.Equal(t, int(now.Month()), int(date.GetMonth()))


### PR DESCRIPTION
This PR adds a new helper function that allows us to parse a `datetime.DateTime` from the given `time.Time` data type.