### PR TITLE
Email sender: AWS SES and Sendgrid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,8 @@ require (
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/prometheus/procfs v0.1.3 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.12.0+incompatible // indirect
 	github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63 // indirect
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,10 @@ github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.12.0+incompatible h1:/N2vx18Fg1KmQOh6zESc5FJB8pYwt5QFBDflYPh1KVg=
+github.com/sendgrid/sendgrid-go v3.12.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63 h1:J6qvD6rbmOil46orKqJaRPG+zTpoGlBTUdyv8ki63L0=
 github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63/go.mod h1:n+VKSARF5y/tS9XFSP7vWDfS+GUC5vs/YT7M5XDTUEM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/mailing/sender.go
+++ b/mailing/sender.go
@@ -1,6 +1,11 @@
 package mailing
 
-import "errors"
+import (
+	"context"
+	"errors"
+	"github.com/sendgrid/rest"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+)
 
 // charset is the default email encoding.
 const charset = "UTF-8"
@@ -22,5 +27,9 @@ var (
 type Sender interface {
 	// Send sends an email from sender to the given recipients. The email body is described by a template
 	// that contains the information passed through data.
-	Send(recipients []string, sender, subject, template string, data any) error
+	Send(ctx context.Context, recipients []string, sender, subject, template string, data any) error
+}
+
+type sendgridSender interface {
+	SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error)
 }

--- a/mailing/sender.go
+++ b/mailing/sender.go
@@ -25,11 +25,14 @@ var (
 
 // Sender allows sending emails through an email service.
 type Sender interface {
-	// Send sends an email from sender to the given recipients. The email body is described by a template
-	// that contains the information passed through data.
-	Send(ctx context.Context, recipients []string, sender, subject, template string, data any) error
+	// Send sends an email from sender to the given recipients. The email body is composed by an HTML template
+	// that is filled in with values provided in data.
+	Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error
 }
 
+// sendgridSender defines the method used by sendgrid to send emails.
+// This interface allow us to mock sending emails in tests.
 type sendgridSender interface {
+	// SendWithContext sends the given email using Sendgrid.
 	SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error)
 }

--- a/mailing/sender.go
+++ b/mailing/sender.go
@@ -1,0 +1,26 @@
+package mailing
+
+import "errors"
+
+// charset is the default email encoding.
+const charset = "UTF-8"
+
+var (
+	// ErrEmptyRecipientList is returned when an empty recipient list is passed to the Sender.Send method.
+	ErrEmptyRecipientList = errors.New("empty recipient list")
+	// ErrEmptySender is returned when an empty sender email address is passed to the Sender.Send method.
+	ErrEmptySender = errors.New("empty sender")
+	// ErrInvalidSender is returned when an invalid email address is passed to the Sender.Send method.
+	ErrInvalidSender = errors.New("invalid sender")
+	// ErrInvalidRecipient is returned when an invalid email is passed in the list of recipients to the Sender.Send method.
+	ErrInvalidRecipient = errors.New("invalid recipient")
+	// ErrInvalidData is returned when an invalid data is passed to the Sender.Send method.
+	ErrInvalidData = errors.New("invalid data")
+)
+
+// Sender allows sending emails through an email service.
+type Sender interface {
+	// Send sends an email from sender to the given recipients. The email body is described by a template
+	// that contains the information passed through data.
+	Send(recipients []string, sender, subject, template string, data any) error
+}

--- a/mailing/sender_test.go
+++ b/mailing/sender_test.go
@@ -1,0 +1,3 @@
+package mailing
+
+const templatePath = "testdata/template.gohtml"

--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -55,17 +55,17 @@ func prepareSendgridMailV3(sender string, recipients []string, cc []string, bcc 
 	return m
 }
 
-// NewSendgridEmailSender initializes a new Sender with a sendgrid client.
-func NewSendgridEmailSender(client sendgridSender) Sender {
-	return &sendgridEmailService{
-		client: client,
-	}
-}
-
 func parseSendgridEmails(emails []string) []*mail.Email {
 	out := make([]*mail.Email, len(emails))
 	for i := 0; i < len(emails); i++ {
 		out[i] = mail.NewEmail("", emails[i])
 	}
 	return out
+}
+
+// NewSendgridEmailSender initializes a new Sender with a sendgrid client.
+func NewSendgridEmailSender(client sendgridSender) Sender {
+	return &sendgridEmailService{
+		client: client,
+	}
 }

--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -18,8 +18,9 @@ type sendgridEmailService struct {
 // Send sends an email from sender to the given recipients. The email body is composed by an HTML template
 // that is filled in with values provided in data.
 func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
-	if len(recipients) == 0 {
-		return nil
+	err := validateEmail(recipients, sender, data)
+	if err != nil {
+		return err
 	}
 
 	htmlContent, err := gz.ParseHTMLTemplate(template, data)

--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -18,7 +18,7 @@ type sendgridEmailService struct {
 // Send sends an email from sender to the given recipients. The email body is composed by an HTML template
 // that is filled in with values provided in data.
 func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
-	err := validateEmail(recipients, sender, data)
+	err := validateEmail(sender, recipients, cc, bcc, data)
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipien
 		return err
 	}
 
-	m := prepareSendgridMailV3(sender, recipients, subject, htmlContent)
+	m := prepareSendgridMailV3(sender, recipients, cc, bcc, subject, htmlContent)
 
 	res, err := s.client.SendWithContext(ctx, m)
 	if err != nil {
@@ -41,10 +41,12 @@ func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipien
 }
 
 // prepareSendgridMailV3 prepares the input values used for sending an email.
-func prepareSendgridMailV3(sender string, recipients []string, subject string, htmlContent string) *mail.SGMailV3 {
+func prepareSendgridMailV3(sender string, recipients []string, cc []string, bcc []string, subject string, htmlContent string) *mail.SGMailV3 {
 	p := mail.NewPersonalization()
 	p.AddFrom(mail.NewEmail("", sender))
 	p.AddTos(parseSendgridEmails(recipients)...)
+	p.AddCCs(parseSendgridEmails(cc)...)
+	p.AddBCCs(parseSendgridEmails(bcc)...)
 	p.Subject = subject
 
 	m := mail.NewV3Mail()

--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -15,26 +15,41 @@ type sendgridEmailService struct {
 	client sendgridSender
 }
 
-// Send sends an email from sender to the given recipients. The email body is described by a template
-// that contains the information passed through data.
-func (s *sendgridEmailService) Send(ctx context.Context, recipients []string, sender, subject, template string, data any) error {
-	from := mail.NewEmail("", sender)
+// Send sends an email from sender to the given recipients. The email body is composed by an HTML template
+// that is filled in with values provided in data.
+func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
+	if len(recipients) == 0 {
+		return nil
+	}
+
 	htmlContent, err := gz.ParseHTMLTemplate(template, data)
 	if err != nil {
 		return err
 	}
-	for _, recipient := range recipients {
-		to := mail.NewEmail("", recipient)
-		m := mail.NewSingleEmail(from, subject, to, "", htmlContent)
-		res, err := s.client.SendWithContext(ctx, m)
-		if err != nil {
-			return err
-		}
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to send email: (%d) %s", res.StatusCode, http.StatusText(res.StatusCode))
-		}
+
+	m := prepareSendgridMailV3(sender, recipients, subject, htmlContent)
+
+	res, err := s.client.SendWithContext(ctx, m)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send email: (%d) %s", res.StatusCode, http.StatusText(res.StatusCode))
 	}
 	return nil
+}
+
+// prepareSendgridMailV3 prepares the input values used for sending an email.
+func prepareSendgridMailV3(sender string, recipients []string, subject string, htmlContent string) *mail.SGMailV3 {
+	p := mail.NewPersonalization()
+	p.AddFrom(mail.NewEmail("", sender))
+	p.AddTos(parseSendgridEmails(recipients)...)
+	p.Subject = subject
+
+	m := mail.NewV3Mail()
+	m.AddPersonalizations(p)
+	m.AddContent(mail.NewContent("text/html", htmlContent))
+	return m
 }
 
 // NewSendgridEmailSender initializes a new Sender with a sendgrid client.
@@ -42,4 +57,12 @@ func NewSendgridEmailSender(client sendgridSender) Sender {
 	return &sendgridEmailService{
 		client: client,
 	}
+}
+
+func parseSendgridEmails(emails []string) []*mail.Email {
+	out := make([]*mail.Email, len(emails))
+	for i := 0; i < len(emails); i++ {
+		out[i] = mail.NewEmail("", emails[i])
+	}
+	return out
 }

--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -1,0 +1,45 @@
+package mailing
+
+import (
+	"context"
+	"fmt"
+	"github.com/gazebo-web/gz-go/v8"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	"net/http"
+)
+
+// sendgridEmailService implements the Sender interface using Sendgrid.
+//
+//	Reference: https://github.com/sendgrid/sendgrid-go
+type sendgridEmailService struct {
+	client sendgridSender
+}
+
+// Send sends an email from sender to the given recipients. The email body is described by a template
+// that contains the information passed through data.
+func (s *sendgridEmailService) Send(ctx context.Context, recipients []string, sender, subject, template string, data any) error {
+	from := mail.NewEmail("", sender)
+	htmlContent, err := gz.ParseHTMLTemplate(template, data)
+	if err != nil {
+		return err
+	}
+	for _, recipient := range recipients {
+		to := mail.NewEmail("", recipient)
+		m := mail.NewSingleEmail(from, subject, to, "", htmlContent)
+		res, err := s.client.SendWithContext(ctx, m)
+		if err != nil {
+			return err
+		}
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to send email: (%d) %s", res.StatusCode, http.StatusText(res.StatusCode))
+		}
+	}
+	return nil
+}
+
+// NewSendgridEmailSender initializes a new Sender with a sendgrid client.
+func NewSendgridEmailSender(client sendgridSender) Sender {
+	return &sendgridEmailService{
+		client: client,
+	}
+}

--- a/mailing/sendgrid_test.go
+++ b/mailing/sendgrid_test.go
@@ -1,0 +1,144 @@
+package mailing
+
+import (
+	"context"
+	"errors"
+	"github.com/gazebo-web/gz-go/v8"
+	"github.com/sendgrid/rest"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"testing"
+)
+
+func TestSendgrid(t *testing.T) {
+	suite.Run(t, new(SendgridTestSuite))
+}
+
+type SendgridTestSuite struct {
+	suite.Suite
+	client      sendgridMock
+	emailSender Sender
+}
+
+func (suite *SendgridTestSuite) SetupTest() {
+	suite.client = sendgridMock{}
+	suite.emailSender = NewSendgridEmailSender(&suite.client)
+	suite.Require().NotNil(suite.emailSender)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_NoRecipients() {
+	const sender = "test@gazebosim.org"
+	const subject = "Test email"
+	ctx := context.Background()
+
+	from := mail.NewEmail("", sender)
+	to := mail.NewEmail("", "")
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	sendgridEmail := mail.NewSingleEmail(from, subject, to, "", htmlContent)
+
+	suite.Assert().NoError(suite.emailSender.Send(ctx, []string{}, sender, subject, templatePath, data))
+
+	suite.client.AssertNotCalled(suite.T(), "SendWithContext", ctx, sendgridEmail)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_Error() {
+	recipients := []string{"test2@gazebosim.org"}
+	const sender = "test@gazebosim.org"
+	const subject = "Test email"
+	ctx := context.Background()
+
+	from := mail.NewEmail("", sender)
+	to := mail.NewEmail("", recipients[0])
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	sendgridEmail := mail.NewSingleEmail(from, subject, to, "", htmlContent)
+
+	expectedError := errors.New("sendgrid failure")
+	suite.client.On("SendWithContext", ctx, sendgridEmail).Return((*rest.Response)(nil), expectedError)
+
+	err = suite.emailSender.Send(ctx, recipients, sender, subject, templatePath, data)
+	suite.Require().Error(err)
+	suite.Assert().ErrorIs(err, expectedError)
+
+	suite.client.AssertCalled(suite.T(), "SendWithContext", ctx, sendgridEmail)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_StatusCode() {
+	recipients := []string{"test2@gazebosim.org"}
+	const sender = "test@gazebosim.org"
+	const subject = "Test email"
+	ctx := context.Background()
+
+	from := mail.NewEmail("", sender)
+	to := mail.NewEmail("", recipients[0])
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	sendgridEmail := mail.NewSingleEmail(from, subject, to, "", htmlContent)
+
+	suite.client.On("SendWithContext", ctx, sendgridEmail).Return(&rest.Response{StatusCode: http.StatusServiceUnavailable}, error(nil))
+	suite.Assert().Error(suite.emailSender.Send(ctx, recipients, sender, subject, templatePath, data))
+
+	suite.client.AssertCalled(suite.T(), "SendWithContext", ctx, sendgridEmail)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_Success() {
+	recipients := []string{"test2@gazebosim.org"}
+	const sender = "test@gazebosim.org"
+	const subject = "Test email"
+	ctx := context.Background()
+
+	from := mail.NewEmail("", sender)
+	to := mail.NewEmail("", recipients[0])
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	sendgridEmail := mail.NewSingleEmail(from, subject, to, "", htmlContent)
+
+	suite.client.On("SendWithContext", ctx, sendgridEmail).Return(&rest.Response{StatusCode: http.StatusOK}, error(nil))
+	suite.Assert().NoError(suite.emailSender.Send(ctx, recipients, sender, subject, templatePath, data))
+
+	suite.client.AssertCalled(suite.T(), "SendWithContext", ctx, sendgridEmail)
+}
+
+type sendgridMock struct {
+	mock.Mock
+}
+
+func (s *sendgridMock) SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error) {
+	args := s.Called(ctx, email)
+	return args.Get(0).(*rest.Response), args.Error(1)
+}

--- a/mailing/sendgrid_test.go
+++ b/mailing/sendgrid_test.go
@@ -44,8 +44,49 @@ func (suite *SendgridTestSuite) TestSendEmail_NoRecipients() {
 
 	m := prepareSendgridMailV3(sender, nil, subject, htmlContent)
 
-	suite.Assert().NoError(suite.emailSender.Send(ctx, sender, []string{}, nil, nil, subject, templatePath, data))
+	suite.Assert().Error(suite.emailSender.Send(ctx, sender, []string{}, nil, nil, subject, templatePath, data))
 
+	suite.client.AssertNotCalled(suite.T(), "SendWithContext", ctx, m)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_InvalidSenderEmail() {
+	const sender = "test.org"
+	const subject = "Test email"
+	ctx := context.Background()
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	m := prepareSendgridMailV3(sender, nil, subject, htmlContent)
+
+	suite.Assert().Error(suite.emailSender.Send(ctx, sender, []string{}, nil, nil, subject, templatePath, data))
+	suite.client.AssertNotCalled(suite.T(), "SendWithContext", ctx, m)
+}
+
+func (suite *SendgridTestSuite) TestSendEmail_RecipientEmail() {
+	const sender = "test@gazebosim.org"
+	const subject = "Test email"
+	recipients := []string{"test.org"}
+	ctx := context.Background()
+
+	type emailData struct {
+		Test string
+	}
+
+	data := emailData{Test: "Hello there!"}
+
+	htmlContent, err := gz.ParseHTMLTemplate(templatePath, data)
+	suite.Require().NoError(err)
+
+	m := prepareSendgridMailV3(sender, nil, subject, htmlContent)
+
+	suite.Assert().Error(suite.emailSender.Send(ctx, sender, recipients, nil, nil, subject, templatePath, data))
 	suite.client.AssertNotCalled(suite.T(), "SendWithContext", ctx, m)
 }
 

--- a/mailing/ses.go
+++ b/mailing/ses.go
@@ -1,0 +1,90 @@
+package mailing
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/ses/sesiface"
+	"github.com/gazebo-web/gz-go/v8"
+)
+
+// simpleEmailService implements the Sender interface using AWS Simple Email Service API.
+type simpleEmailService struct {
+	API sesiface.SESAPI
+}
+
+// Send sends an email to the given recipients from the given sender.
+// A template will be parsed with the given data in order to fill the email's body.
+// It returns an error when validation fails or sending an email fails.
+func (e *simpleEmailService) Send(recipients []string, sender, subject, template string, data interface{}) error {
+	err := validEmail(recipients, sender, data)
+	if err != nil {
+		return err
+	}
+
+	content, err := gz.ParseHTMLTemplate(template, data)
+	if err != nil {
+		return err
+	}
+
+	err = e.send(sender, recipients, subject, content)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// send attempts to send an email using the AWS SES service.
+func (e *simpleEmailService) send(sender string, recipients []string, subject string, content string) error {
+	input := ses.SendEmailInput{
+		Destination: &ses.Destination{
+			CcAddresses: []*string{},
+			ToAddresses: aws.StringSlice(recipients),
+		},
+		Message: &ses.Message{
+			Body: &ses.Body{
+				Html: &ses.Content{
+					Charset: aws.String(charset),
+					Data:    aws.String(content),
+				},
+			},
+			Subject: &ses.Content{
+				Charset: aws.String(charset),
+				Data:    aws.String(subject),
+			},
+		},
+		Source: aws.String(sender),
+	}
+
+	// Attempt to send the simpleEmailService.
+	_, err := e.API.SendEmail(&input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			var code string
+			switch aerr.Code() {
+			case ses.ErrCodeMessageRejected:
+				code = ses.ErrCodeMessageRejected
+			case ses.ErrCodeMailFromDomainNotVerifiedException:
+				code = ses.ErrCodeMailFromDomainNotVerifiedException
+			case ses.ErrCodeConfigurationSetDoesNotExistException:
+				code = ses.ErrCodeConfigurationSetDoesNotExistException
+			default:
+				code = "Unknown AWS SES error"
+			}
+			return fmt.Errorf("%s %s", code, aerr.Error())
+		}
+		return errors.New(err.Error())
+	}
+
+	return nil
+}
+
+// NewSimpleEmailServiceSender returns a Sender implementation using AWS Simple Email Service.
+func NewSimpleEmailServiceSender(api sesiface.SESAPI) Sender {
+	return &simpleEmailService{
+		API: api,
+	}
+}

--- a/mailing/ses.go
+++ b/mailing/ses.go
@@ -21,10 +21,9 @@ type awsSimpleEmailService struct {
 	API sesiface.SESAPI
 }
 
-// Send sends an email to the given recipients from the given sender.
-// A template will be parsed with the given data in order to fill the email's body.
-// It returns an error when validation fails or sending an email fails.
-func (e *awsSimpleEmailService) Send(ctx context.Context, recipients []string, sender, subject, template string, data any) error {
+// Send sends an email from sender to the given recipients. The email body is composed by an HTML template
+// that is filled in with values provided in data.
+func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
 	err := validEmail(recipients, sender, data)
 	if err != nil {
 		return err

--- a/mailing/ses.go
+++ b/mailing/ses.go
@@ -24,7 +24,7 @@ type awsSimpleEmailService struct {
 // Send sends an email from sender to the given recipients. The email body is composed by an HTML template
 // that is filled in with values provided in data.
 func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
-	err := validateEmail(recipients, sender, data)
+	err := validateEmail(sender, recipients, cc, bcc, data)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipie
 		return err
 	}
 
-	err = e.send(ctx, sender, recipients, subject, content)
+	err = e.send(ctx, sender, recipients, nil, nil, subject, content)
 	if err != nil {
 		return err
 	}
@@ -43,11 +43,12 @@ func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipie
 }
 
 // send attempts to send an email using the AWS SES service.
-func (e *awsSimpleEmailService) send(_ context.Context, sender string, recipients []string, subject string, content string) error {
+func (e *awsSimpleEmailService) send(_ context.Context, sender string, recipients []string, cc []string, bcc []string, subject string, content string) error {
 	input := ses.SendEmailInput{
 		Destination: &ses.Destination{
-			CcAddresses: []*string{},
-			ToAddresses: aws.StringSlice(recipients),
+			CcAddresses:  aws.StringSlice(cc),
+			BccAddresses: aws.StringSlice(bcc),
+			ToAddresses:  aws.StringSlice(recipients),
 		},
 		Message: &ses.Message{
 			Body: &ses.Body{

--- a/mailing/ses.go
+++ b/mailing/ses.go
@@ -34,7 +34,7 @@ func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipie
 		return err
 	}
 
-	err = e.send(ctx, sender, recipients, nil, nil, subject, content)
+	err = e.send(ctx, sender, recipients, cc, bcc, subject, content)
 	if err != nil {
 		return err
 	}

--- a/mailing/ses.go
+++ b/mailing/ses.go
@@ -24,7 +24,7 @@ type awsSimpleEmailService struct {
 // Send sends an email from sender to the given recipients. The email body is composed by an HTML template
 // that is filled in with values provided in data.
 func (e *awsSimpleEmailService) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
-	err := validEmail(recipients, sender, data)
+	err := validateEmail(recipients, sender, data)
 	if err != nil {
 		return err
 	}

--- a/mailing/ses_test.go
+++ b/mailing/ses_test.go
@@ -1,0 +1,84 @@
+package mailing
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/ses/sesiface"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmailReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
+	s := NewSimpleEmailServiceSender(nil)
+
+	err := s.Send(nil, "example@test.org", "Some test", "test.template", nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrEmptyRecipientList, err)
+}
+
+func TestEmailReturnsErrWhenSenderIsEmpty(t *testing.T) {
+	s := NewSimpleEmailServiceSender(nil)
+
+	err := s.Send([]string{"recipient@test.org"}, "", "Some test", "test.template", nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrEmptySender, err)
+}
+
+func TestEmailReturnsErrWhenRecipientIsInvalid(t *testing.T) {
+	s := NewSimpleEmailServiceSender(nil)
+
+	err := s.Send([]string{"ThisIsNotAValidEmail"}, "example@test.org", "Some test", "test.template", nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidRecipient, err)
+}
+
+func TestEmailReturnsErrWhenSenderIsInvalid(t *testing.T) {
+	s := NewSimpleEmailServiceSender(nil)
+
+	err := s.Send([]string{"recipient@test.org"}, "InvalidSenderEmail", "Some test", "test.template", nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidSender, err)
+}
+
+func TestEmailReturnsErrWhenInvalidPath(t *testing.T) {
+	s := NewSimpleEmailServiceSender(nil)
+
+	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "test", nil)
+	assert.Error(t, err)
+}
+
+func TestEmailReturnsErrWhenDataIsNil(t *testing.T) {
+	s := NewSimpleEmailServiceSender(&fakeSender{})
+	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidData, err)
+}
+
+func TestEmailSendingSuccess(t *testing.T) {
+	fake := fakeSender{}
+	s := NewSimpleEmailServiceSender(&fake)
+	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", struct {
+		Test string
+	}{
+		Test: "Hello there!",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, fake.Called)
+}
+
+// fakeSender fakes the sesiface.SESAPI interface.
+type fakeSender struct {
+	returnError bool
+	Called      int
+	sesiface.SESAPI
+}
+
+// SendEmail mocks the SendEmail method from the sesiface.SESAPI.
+func (s *fakeSender) SendEmail(input *ses.SendEmailInput) (*ses.SendEmailOutput, error) {
+	s.Called++
+	if s.returnError {
+		return nil, errors.New("fake error")
+	}
+	return nil, nil
+}

--- a/mailing/ses_test.go
+++ b/mailing/ses_test.go
@@ -1,7 +1,7 @@
 package mailing
 
 import (
-	context2 "context"
+	"context"
 	"errors"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/aws/aws-sdk-go/service/ses/sesiface"
@@ -12,7 +12,7 @@ import (
 func TestSES_ReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(context2.Background(), nil, "example@test.org", "Some test", "test.template", nil)
+	err := s.Send(context.Background(), "example@test.org", nil, nil, nil, "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrEmptyRecipientList, err)
 }
@@ -20,7 +20,7 @@ func TestSES_ReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 func TestSES_ReturnsErrWhenSenderIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "", "Some test", "test.template", nil)
+	err := s.Send(context.Background(), "", []string{"recipient@test.org"}, nil, nil, "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrEmptySender, err)
 }
@@ -28,7 +28,7 @@ func TestSES_ReturnsErrWhenSenderIsEmpty(t *testing.T) {
 func TestSES_ReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(context2.Background(), []string{"ThisIsNotAValidEmail"}, "example@test.org", "Some test", "test.template", nil)
+	err := s.Send(context.Background(), "example@test.org", []string{"ThisIsNotAValidEmail"}, nil, nil, "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidRecipient, err)
 }
@@ -36,7 +36,7 @@ func TestSES_ReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 func TestSES_ReturnsErrWhenSenderIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "InvalidSenderEmail", "Some test", "test.template", nil)
+	err := s.Send(context.Background(), "InvalidSenderEmail", []string{"recipient@test.org"}, nil, nil, "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidSender, err)
 }
@@ -44,13 +44,13 @@ func TestSES_ReturnsErrWhenSenderIsInvalid(t *testing.T) {
 func TestSES_ReturnsErrWhenInvalidPath(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", "test", nil)
+	err := s.Send(context.Background(), "example@test.org", []string{"recipient@test.org"}, nil, nil, "Some test", "test", nil)
 	assert.Error(t, err)
 }
 
 func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
 	s := NewSimpleEmailServiceSender(&fakeSESSender{})
-	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", templatePath, nil)
+	err := s.Send(context.Background(), "example@test.org", []string{"recipient@test.org"}, nil, nil, "Some test", templatePath, nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidData, err)
 }
@@ -58,7 +58,7 @@ func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
 func TestSES_SendingSuccess(t *testing.T) {
 	fake := fakeSESSender{}
 	s := NewSimpleEmailServiceSender(&fake)
-	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", templatePath, struct {
+	err := s.Send(context.Background(), "example@test.org", []string{"recipient@test.org"}, nil, nil, "Some test", templatePath, struct {
 		Test string
 	}{
 		Test: "Hello there!",

--- a/mailing/ses_test.go
+++ b/mailing/ses_test.go
@@ -55,6 +55,20 @@ func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
 	assert.Equal(t, ErrInvalidData, err)
 }
 
+func TestSES_ReturnsErrWhenCCIsInvalid(t *testing.T) {
+	s := NewSimpleEmailServiceSender(&fakeSESSender{})
+	err := s.Send(context.Background(), "example@test.org", []string{"recipient@test.org"}, []string{"test.org"}, nil, "Some test", templatePath, nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidRecipient, err)
+}
+
+func TestSES_ReturnsErrWhenBCCIsInvalid(t *testing.T) {
+	s := NewSimpleEmailServiceSender(&fakeSESSender{})
+	err := s.Send(context.Background(), "example@test.org", []string{"recipient@test.org"}, nil, []string{"test.org"}, "Some test", templatePath, nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidRecipient, err)
+}
+
 func TestSES_SendingSuccess(t *testing.T) {
 	fake := fakeSESSender{}
 	s := NewSimpleEmailServiceSender(&fake)

--- a/mailing/ses_test.go
+++ b/mailing/ses_test.go
@@ -1,6 +1,7 @@
 package mailing
 
 import (
+	context2 "context"
 	"errors"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/aws/aws-sdk-go/service/ses/sesiface"
@@ -11,7 +12,7 @@ import (
 func TestSES_ReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send(nil, "example@test.org", "Some test", "test.template", nil)
+	err := s.Send(context2.Background(), nil, "example@test.org", "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrEmptyRecipientList, err)
 }
@@ -19,7 +20,7 @@ func TestSES_ReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 func TestSES_ReturnsErrWhenSenderIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send([]string{"recipient@test.org"}, "", "Some test", "test.template", nil)
+	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "", "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrEmptySender, err)
 }
@@ -27,7 +28,7 @@ func TestSES_ReturnsErrWhenSenderIsEmpty(t *testing.T) {
 func TestSES_ReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send([]string{"ThisIsNotAValidEmail"}, "example@test.org", "Some test", "test.template", nil)
+	err := s.Send(context2.Background(), []string{"ThisIsNotAValidEmail"}, "example@test.org", "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidRecipient, err)
 }
@@ -35,7 +36,7 @@ func TestSES_ReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 func TestSES_ReturnsErrWhenSenderIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send([]string{"recipient@test.org"}, "InvalidSenderEmail", "Some test", "test.template", nil)
+	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "InvalidSenderEmail", "Some test", "test.template", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidSender, err)
 }
@@ -43,13 +44,13 @@ func TestSES_ReturnsErrWhenSenderIsInvalid(t *testing.T) {
 func TestSES_ReturnsErrWhenInvalidPath(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
-	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "test", nil)
+	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", "test", nil)
 	assert.Error(t, err)
 }
 
 func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
 	s := NewSimpleEmailServiceSender(&fakeSESSender{})
-	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", nil)
+	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", templatePath, nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidData, err)
 }
@@ -57,7 +58,7 @@ func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
 func TestSES_SendingSuccess(t *testing.T) {
 	fake := fakeSESSender{}
 	s := NewSimpleEmailServiceSender(&fake)
-	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", struct {
+	err := s.Send(context2.Background(), []string{"recipient@test.org"}, "example@test.org", "Some test", templatePath, struct {
 		Test string
 	}{
 		Test: "Hello there!",

--- a/mailing/ses_test.go
+++ b/mailing/ses_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestEmailReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
+func TestSES_ReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
 	err := s.Send(nil, "example@test.org", "Some test", "test.template", nil)
@@ -16,7 +16,7 @@ func TestEmailReturnsErrWhenRecipientsIsEmpty(t *testing.T) {
 	assert.Equal(t, ErrEmptyRecipientList, err)
 }
 
-func TestEmailReturnsErrWhenSenderIsEmpty(t *testing.T) {
+func TestSES_ReturnsErrWhenSenderIsEmpty(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
 	err := s.Send([]string{"recipient@test.org"}, "", "Some test", "test.template", nil)
@@ -24,7 +24,7 @@ func TestEmailReturnsErrWhenSenderIsEmpty(t *testing.T) {
 	assert.Equal(t, ErrEmptySender, err)
 }
 
-func TestEmailReturnsErrWhenRecipientIsInvalid(t *testing.T) {
+func TestSES_ReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
 	err := s.Send([]string{"ThisIsNotAValidEmail"}, "example@test.org", "Some test", "test.template", nil)
@@ -32,7 +32,7 @@ func TestEmailReturnsErrWhenRecipientIsInvalid(t *testing.T) {
 	assert.Equal(t, ErrInvalidRecipient, err)
 }
 
-func TestEmailReturnsErrWhenSenderIsInvalid(t *testing.T) {
+func TestSES_ReturnsErrWhenSenderIsInvalid(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
 	err := s.Send([]string{"recipient@test.org"}, "InvalidSenderEmail", "Some test", "test.template", nil)
@@ -40,22 +40,22 @@ func TestEmailReturnsErrWhenSenderIsInvalid(t *testing.T) {
 	assert.Equal(t, ErrInvalidSender, err)
 }
 
-func TestEmailReturnsErrWhenInvalidPath(t *testing.T) {
+func TestSES_ReturnsErrWhenInvalidPath(t *testing.T) {
 	s := NewSimpleEmailServiceSender(nil)
 
 	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "test", nil)
 	assert.Error(t, err)
 }
 
-func TestEmailReturnsErrWhenDataIsNil(t *testing.T) {
-	s := NewSimpleEmailServiceSender(&fakeSender{})
+func TestSES_ReturnsErrWhenDataIsNil(t *testing.T) {
+	s := NewSimpleEmailServiceSender(&fakeSESSender{})
 	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", nil)
 	assert.Error(t, err)
 	assert.Equal(t, ErrInvalidData, err)
 }
 
-func TestEmailSendingSuccess(t *testing.T) {
-	fake := fakeSender{}
+func TestSES_SendingSuccess(t *testing.T) {
+	fake := fakeSESSender{}
 	s := NewSimpleEmailServiceSender(&fake)
 	err := s.Send([]string{"recipient@test.org"}, "example@test.org", "Some test", "testdata/template.gohtml", struct {
 		Test string
@@ -67,15 +67,15 @@ func TestEmailSendingSuccess(t *testing.T) {
 	assert.Equal(t, 1, fake.Called)
 }
 
-// fakeSender fakes the sesiface.SESAPI interface.
-type fakeSender struct {
+// fakeSESSender fakes the sesiface.SESAPI interface.
+type fakeSESSender struct {
 	returnError bool
 	Called      int
 	sesiface.SESAPI
 }
 
 // SendEmail mocks the SendEmail method from the sesiface.SESAPI.
-func (s *fakeSender) SendEmail(input *ses.SendEmailInput) (*ses.SendEmailOutput, error) {
+func (s *fakeSESSender) SendEmail(input *ses.SendEmailInput) (*ses.SendEmailOutput, error) {
 	s.Called++
 	if s.returnError {
 		return nil, errors.New("fake error")

--- a/mailing/testdata/template.gohtml
+++ b/mailing/testdata/template.gohtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<body>
+<p>This is an amazing email for testing purposes. Here is your email data: {{ .Test }}</p>
+<p>Open Robotics Team</p>
+</body>
+</html>

--- a/mailing/validation.go
+++ b/mailing/validation.go
@@ -8,8 +8,8 @@ func validateEmailAddress(email string) bool {
 	return exp.MatchString(email)
 }
 
-// validEmail validates that the given parameters for an email are valid.
-func validEmail(recipients []string, sender string, data any) error {
+// validateEmail validates that the given parameters for an email are valid.
+func validateEmail(recipients []string, sender string, data any) error {
 	if len(recipients) == 0 {
 		return ErrEmptyRecipientList
 	}

--- a/mailing/validation.go
+++ b/mailing/validation.go
@@ -1,0 +1,31 @@
+package mailing
+
+import "regexp"
+
+// validateEmailAddress validates the given email is a valid email address.
+func validateEmailAddress(email string) bool {
+	exp := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	return exp.MatchString(email)
+}
+
+// validEmail validates that the given parameters for an email are valid.
+func validEmail(recipients []string, sender string, data any) error {
+	if len(recipients) == 0 {
+		return ErrEmptyRecipientList
+	}
+	if len(sender) == 0 {
+		return ErrEmptySender
+	}
+	for _, r := range recipients {
+		if ok := validateEmailAddress(r); !ok {
+			return ErrInvalidRecipient
+		}
+	}
+	if ok := validateEmailAddress(sender); !ok {
+		return ErrInvalidSender
+	}
+	if data == nil {
+		return ErrInvalidData
+	}
+	return nil
+}

--- a/mailing/validation.go
+++ b/mailing/validation.go
@@ -9,7 +9,7 @@ func validateEmailAddress(email string) bool {
 }
 
 // validateEmail validates that the given parameters for an email are valid.
-func validateEmail(recipients []string, sender string, data any) error {
+func validateEmail(sender string, recipients []string, cc []string, bcc []string, data any) error {
 	if len(recipients) == 0 {
 		return ErrEmptyRecipientList
 	}
@@ -24,6 +24,17 @@ func validateEmail(recipients []string, sender string, data any) error {
 	if ok := validateEmailAddress(sender); !ok {
 		return ErrInvalidSender
 	}
+	for _, r := range cc {
+		if ok := validateEmailAddress(r); !ok {
+			return ErrInvalidRecipient
+		}
+	}
+	for _, r := range bcc {
+		if ok := validateEmailAddress(r); !ok {
+			return ErrInvalidRecipient
+		}
+	}
+
 	if data == nil {
 		return ErrInvalidData
 	}


### PR DESCRIPTION
This PR allow us to send emails with AWS Simple Email Service (SES) and Sendgrid.

The AWS SES implementation was migrated from Cloudsim, with a few minor improvements.
The Sendgrid implementation was created from scratch, using the Sendgrid Go SDK.