### PR TITLE
Add nop email sender implementation

### DIFF
--- a/mailing/nop.go
+++ b/mailing/nop.go
@@ -1,0 +1,17 @@
+package mailing
+
+import "context"
+
+// nop implements Sender but doesn't interact with any email service provider.
+type nop struct{}
+
+// Send doesn't send an email.
+func (n *nop) Send(ctx context.Context, sender string, recipients, cc, bcc []string, subject, template string, data any) error {
+	return nil
+}
+
+// NewNopEmailSender returns a no-op Sender. It never interacts with an email service provider.
+// This Sender implementation is useful when a service doesn't want to enable sending emails.
+func NewNopEmailSender() Sender {
+	return &nop{}
+}


### PR DESCRIPTION
This PR allow us to default to have a sensible default email implementation in services that don't want to enable sending emails for a particular reason (testing).