### PR TITLE
Add ToMap function to structs package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/codegangsta/negroni v1.0.0
 	github.com/creasty/defaults v1.7.0
+	github.com/fatih/structs v1.1.0
 	github.com/fatih/structtag v1.2.0
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/fsouza/fake-gcs-server v1.45.2
@@ -32,6 +33,8 @@ require (
 	github.com/rollbar/rollbar-go v1.2.0
 	github.com/rs/cors v1.9.0
 	github.com/satori/go.uuid v1.2.0
+	github.com/sendgrid/rest v2.6.9+incompatible
+	github.com/sendgrid/sendgrid-go v3.12.0+incompatible
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/negroni v1.0.0
 	gitlab.com/ignitionrobotics/web/scheduler v0.5.0
@@ -112,8 +115,6 @@ require (
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/prometheus/procfs v0.1.3 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
-	github.com/sendgrid/rest v2.6.9+incompatible // indirect
-	github.com/sendgrid/sendgrid-go v3.12.0+incompatible // indirect
 	github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63 // indirect
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.10.1 h1:c0g45+xCJhdgFGw7a5QAfdS4byAbud7miNWJ1WwEVf8=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/structs/map.go
+++ b/structs/map.go
@@ -1,0 +1,67 @@
+package structs
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var (
+	// ErrTagEmpty is returned when an empty tag is passed to Map.
+	ErrTagEmpty = errors.New("tag cannot be empty")
+	// ErrInvalidInputType is returned when Map receives an input that is not a struct or a pointer to a struct.
+	ErrInvalidInputType = errors.New("invalid input type")
+)
+
+// Map converts the given struct to a map[string]any. It uses the given tag to identify the key for each map field.
+// If no tag is present in the Struct field, the field is omitted.
+//
+// Considering the following struct:
+//
+//	type Test struct {
+//		Field1 string `test:"field_1"`
+//		Field2 int `test:"field_2"`
+//		Field3 any `test:"field_3"`
+//	}
+//
+// And the following variable:
+//
+//	input := Test{
+//		Field1: "test",
+//		Field2: 1,
+//		Field3: nil,
+//	}
+//
+// Map(input, "test") will return a map as follows:
+//
+//	map[string]any{
+//		"field_1": "test",
+//		"field_2": 1,
+//		"field_3": nil,
+//	}
+//
+// If Map is called with a non-existent tag, an empty map will be returned.
+//
+//	m := Map(input, "not_found")
+//	len(m) == 0 (true)
+func Map(s any, tag string) (map[string]any, error) {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%w, got %T", ErrInvalidInputType, v)
+	}
+	if len(tag) == 0 {
+		return nil, ErrTagEmpty
+	}
+	t := v.Type()
+	out := make(map[string]any)
+	for i := 0; i < v.NumField(); i++ {
+		fi := t.Field(i)
+		if tagValue := fi.Tag.Get(tag); tagValue != "" {
+			out[tagValue] = v.Field(i).Interface()
+		}
+	}
+	return out, nil
+}

--- a/structs/map.go
+++ b/structs/map.go
@@ -25,12 +25,12 @@ var (
 //
 // A tag value with the content of "-" ignores that particular field. Example:
 //
-//	// Field is ignored by this package.
+//	// Field is ignored by this function.
 //	Field bool `structs:"-"`
 //
-// A tag value with the content of "string" uses the stringer to get the value. Example:
+// A tag value with the content of "string" uses Go's Stringer interface to get the value. Example:
 //
-//	// The value will be output of Animal's String() func.
+//	// The value will be the output of Animal's String() func.
 //	// Map will panic if Animal does not implement String().
 //	Field *Animal `structs:"field,string"`
 //

--- a/structs/map.go
+++ b/structs/map.go
@@ -15,9 +15,12 @@ var (
 )
 
 // ToMap converts the given struct to a map[string]any. It uses the "structs" tag to identify the key for each map field.
-// If no tag is present in the Struct field, the field is omitted.
 //
 // The default key string is the struct field name but can be changed in the struct field's tag value.
+//
+//	// Field appears in map as key "Name".
+//	Name string
+//
 // The "structs" key in the struct's field tag value is the key name. Example:
 //
 //	// Field appears in map as key "myName".

--- a/structs/map_test.go
+++ b/structs/map_test.go
@@ -1,0 +1,39 @@
+package structs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type structTest struct {
+	Test string `field:"test"`
+}
+
+func TestMap(t *testing.T) {
+	s := structTest{
+		Test: "value",
+	}
+
+	// Not struct
+	_, err := Map("test", "")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidInputType)
+
+	// Empty tag
+	_, err = Map(s, "")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrTagEmpty)
+
+	// Wrong struct tag returns an empty map
+	wrong, err := Map(s, "invalid")
+	assert.NoError(t, err)
+	assert.Empty(t, wrong)
+
+	// Correct struct tag
+	result, err := Map(s, "field")
+	var expected map[string]any
+	assert.IsType(t, expected, result)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.Equal(t, s.Test, result["test"])
+}

--- a/structs/map_test.go
+++ b/structs/map_test.go
@@ -45,9 +45,9 @@ func TestToMap(t *testing.T) {
 	casted, ok := result["ss"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, s.TestStruct.DeepValue, casted["ss_i"])
-	
+
 	// Struct pointer
-	result, err := ToMap(&s)
+	result, err = ToMap(&s)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
 }

--- a/structs/map_test.go
+++ b/structs/map_test.go
@@ -45,4 +45,9 @@ func TestToMap(t *testing.T) {
 	casted, ok := result["ss"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, s.TestStruct.DeepValue, casted["ss_i"])
+	
+	// Struct pointer
+	result, err := ToMap(&s)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
 }

--- a/structs/map_test.go
+++ b/structs/map_test.go
@@ -5,35 +5,44 @@ import (
 	"testing"
 )
 
-type structTest struct {
-	Test string `field:"test"`
-}
+func TestToMap(t *testing.T) {
+	type structTest struct {
+		TestString string `structs:"s"`
+		TestInt    int    `structs:"i"`
+		TestStruct struct {
+			DeepValue int `structs:"ss_i"`
+		} `structs:"ss"`
+		TestIgnored string `structs:"-"`
+	}
 
-func TestMap(t *testing.T) {
 	s := structTest{
-		Test: "value",
+		TestString: "test",
+		TestInt:    1,
+		TestStruct: struct {
+			DeepValue int `structs:"ss_i"`
+		}{
+			DeepValue: 2,
+		},
+		TestIgnored: "ignored",
 	}
 
 	// Not struct
-	_, err := Map("test", "")
+	_, err := ToMap("test")
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidInputType)
 
-	// Empty tag
-	_, err = Map(s, "")
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrTagEmpty)
-
-	// Wrong struct tag returns an empty map
-	wrong, err := Map(s, "invalid")
-	assert.NoError(t, err)
-	assert.Empty(t, wrong)
-
 	// Correct struct tag
-	result, err := Map(s, "field")
+	result, err := ToMap(s)
 	var expected map[string]any
 	assert.IsType(t, expected, result)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
-	assert.Equal(t, s.Test, result["test"])
+	assert.Equal(t, s.TestString, result["s"])
+	assert.Equal(t, s.TestInt, result["i"])
+	assert.NotContains(t, result, "TestIgnored")
+	assert.NotZero(t, result["ss"])
+
+	casted, ok := result["ss"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, s.TestStruct.DeepValue, casted["ss_i"])
 }


### PR DESCRIPTION
# Context
This PR enables us reading dynamic template parameters from structs when sending emails using sendgrid.

# Change
It adds a new `Map` function in the `structs` package that uses reflection to convert any `struct` to a `map[string]any`.