### PR TITLE
Improve error message on Sendgrid Email Service

### DIFF
--- a/mailing/sendgrid.go
+++ b/mailing/sendgrid.go
@@ -45,7 +45,7 @@ func (s *sendgridEmailService) Send(ctx context.Context, sender string, recipien
 		return err
 	}
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to send email: (%d) %s", res.StatusCode, http.StatusText(res.StatusCode))
+		return fmt.Errorf("failed to send email (%d) %s: %s", res.StatusCode, http.StatusText(res.StatusCode), res.Body)
 	}
 	return nil
 }


### PR DESCRIPTION
We need more context when we're getting an error from sendgrid. This PR adds the body to the error message.