### PR TITLE
Add ArrayString custom SQL type

### DIFF
--- a/database/gorm/array_string_type.go
+++ b/database/gorm/array_string_type.go
@@ -1,0 +1,30 @@
+package gorm
+
+import (
+	"database/sql/driver"
+	"errors"
+	"strings"
+)
+
+// ArrayString is a custom data type for SQL databases. It adds support for an array of strings to MySQL.
+type ArrayString []string
+
+// Value takes the current ArrayString and converts it to a valid SQL value.
+//
+// See driver.Valuer for more details.
+func (arr *ArrayString) Value() (driver.Value, error) {
+	return strings.Join(*arr, ","), nil
+}
+
+// Scan fills out the current ArrayString with the string provided as source. It returns an error if source if not a
+// string.
+//
+// See sql.Scanner for more details.
+func (arr *ArrayString) Scan(src any) error {
+	v, ok := src.(string)
+	if !ok {
+		return errors.New("invalid data type, must be a string")
+	}
+	*arr = strings.Split(v, ",")
+	return nil
+}

--- a/database/gorm/array_string_type_test.go
+++ b/database/gorm/array_string_type_test.go
@@ -9,9 +9,7 @@ import (
 
 func TestArrayString_Scanner(t *testing.T) {
 	var arrstr ArrayString
-	var scanner sql.Scanner
-
-	scanner = &arrstr
+	var scanner sql.Scanner = &arrstr
 
 	assert.Error(t, scanner.Scan([]byte("test")), "Calling Scan must return an error with an invalid type")
 	assert.NoError(t, scanner.Scan("test,test"), "Calling Scan with a string must return no errors")

--- a/database/gorm/array_string_type_test.go
+++ b/database/gorm/array_string_type_test.go
@@ -1,0 +1,37 @@
+package gorm
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestArrayString_Scanner(t *testing.T) {
+	var arrstr ArrayString
+	var scanner sql.Scanner
+
+	scanner = &arrstr
+
+	assert.Error(t, scanner.Scan([]byte("test")), "Calling Scan must return an error with an invalid type")
+	assert.NoError(t, scanner.Scan("test,test"), "Calling Scan with a string must return no errors")
+
+	assert.Len(t, arrstr, 2, "After calling Scan with \"test,test\", the underlying ArrayString must have n elements")
+}
+
+func TestArrayString_Valuer(t *testing.T) {
+	var arrstr ArrayString
+	var valuer driver.Valuer
+
+	arrstr = []string{"test", "test"}
+
+	valuer = &arrstr
+
+	v, err := valuer.Value()
+	assert.NoError(t, err)
+
+	str, ok := v.(string)
+	assert.True(t, ok)
+	assert.Equal(t, "test,test", str)
+
+}


### PR DESCRIPTION
This PR adds a custom SQL type to support a slice of strings to SQL databases that don't support custom types such as MySQL.