### PR TITLE
Make ExtractGRPCMetadata public

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/gazebo-web/auth/pkg/authentication"
 	"github.com/golang-jwt/jwt/v5/request"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	grpc_metadata "google.golang.org/grpc/metadata"
-	"net/http"
 )
 
 // Extractor extracts a string value from an HTTP request. It's usually used to extract a header from an HTTP request,
@@ -64,7 +65,7 @@ const (
 // This function only works with gRPC requests. It returns an error if the metadata couldn't be parsed or the subject
 // is not present.
 func ExtractGRPCAuthSubject(ctx context.Context) (string, error) {
-	return extractGRPCMetadata(ctx, metadataSubjectKey)
+	return ExtractGRPCMetadata(ctx, metadataSubjectKey)
 }
 
 // InjectGRPCAuthSubject injects the authentication subject (sub) claim into the given context metadata.
@@ -82,7 +83,7 @@ func InjectGRPCAuthSubject(ctx context.Context, sub string) context.Context {
 // This function only works with gRPC requests. It returns an error if the metadata couldn't be parsed or the email
 // is not present.
 func ExtractGRPCAuthEmail(ctx context.Context) (string, error) {
-	return extractGRPCMetadata(ctx, metadataEmailKey)
+	return ExtractGRPCMetadata(ctx, metadataEmailKey)
 }
 
 // InjectGRPCAuthEmail injects the custom email (email) claim into the given context metadata.
@@ -92,7 +93,7 @@ func InjectGRPCAuthEmail(ctx context.Context, email string) context.Context {
 }
 
 // extractGRPCMetadata extracts the first value of the given key. This only works for gRPC servers, not clients.
-func extractGRPCMetadata(ctx context.Context, key string) (string, error) {
+func ExtractGRPCMetadata(ctx context.Context, key string) (string, error) {
 	md, ok := grpc_metadata.FromIncomingContext(ctx)
 	if !ok {
 		return "", errors.New("failed to get context metadata")


### PR DESCRIPTION
This PR allows applications to create their custom extractors by exporting the ExtractGRPCMetadata func they can use.