### PR TITLE
Add zero value check functions

### DIFF
--- a/validate/zero.go
+++ b/validate/zero.go
@@ -4,39 +4,39 @@ import "reflect"
 
 // IsZero checks returns true if the provided value is a zero value.
 func IsZero(value any) bool {
-	switch value.(type) {
+	switch v := value.(type) {
 	case string:
-		return value == ""
+		return v == ""
 	case int:
-		return value == 0
+		return v == 0
 	case int8:
-		return value == int8(0)
+		return v == int8(0)
 	case int16:
-		return value == int16(0)
+		return v == int16(0)
 	case int32:
-		return value == int32(0)
+		return v == int32(0)
 	case int64:
-		return value == int64(0)
+		return v == int64(0)
 	case uint:
-		return value == uint(0)
+		return v == uint(0)
 	case uint8:
-		return value == uint8(0)
+		return v == uint8(0)
 	case uint16:
-		return value == uint16(0)
+		return v == uint16(0)
 	case uint32:
-		return value == uint32(0)
+		return v == uint32(0)
 	case uint64:
-		return value == uint64(0)
+		return v == uint64(0)
 	case float32:
-		return value == float32(0)
+		return v == float32(0)
 	case float64:
-		return value == float64(0)
+		return v == float64(0)
 	case complex64:
-		return value == complex64(0)
+		return v == complex64(0)
 	case complex128:
-		return value == complex128(0)
+		return v == complex128(0)
 	case bool:
-		return !value.(bool)
+		return !v
 	default:
 		return reflect.ValueOf(value).IsZero()
 	}

--- a/validate/zero.go
+++ b/validate/zero.go
@@ -1,0 +1,53 @@
+package validate
+
+import "reflect"
+
+// IsZero checks returns true if the provided value is a zero value.
+func IsZero(value any) bool {
+	switch value.(type) {
+	case string:
+		return value == ""
+	case int:
+		return value == 0
+	case int8:
+		return value == int8(0)
+	case int16:
+		return value == int16(0)
+	case int32:
+		return value == int32(0)
+	case int64:
+		return value == int64(0)
+	case uint:
+		return value == uint(0)
+	case uint8:
+		return value == uint8(0)
+	case uint16:
+		return value == uint16(0)
+	case uint32:
+		return value == uint32(0)
+	case uint64:
+		return value == uint64(0)
+	case float32:
+		return value == float32(0)
+	case float64:
+		return value == float64(0)
+	case complex64:
+		return value == complex64(0)
+	case complex128:
+		return value == complex128(0)
+	case bool:
+		return !value.(bool)
+	default:
+		return reflect.ValueOf(value).IsZero()
+	}
+}
+
+// HasZero checks returns true if any of the provided values is a zero value.
+func HasZero(values ...any) bool {
+	for _, value := range values {
+		if IsZero(value) {
+			return true
+		}
+	}
+	return false
+}

--- a/validate/zero_test.go
+++ b/validate/zero_test.go
@@ -1,0 +1,123 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestIsZero(t *testing.T) {
+	type Test struct {
+		V int
+	}
+
+	var zeroStruct Test
+	var zeroStructPtr *Test
+	var zeroMap map[string]any
+	var zeroSlice []string
+
+	tests := []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{name: "string_zero", value: "", want: true},
+		{name: "string_not_zero", value: "test", want: false},
+
+		{name: "int_zero", value: 0, want: true},
+		{name: "int_not_zero", value: 4, want: false},
+
+		{name: "int8_zero", value: int8(0), want: true},
+		{name: "int8_not_zero", value: int8(4), want: false},
+
+		{name: "int16_zero", value: int16(0), want: true},
+		{name: "int16_not_zero", value: int16(4), want: false},
+
+		{name: "int32_zero", value: int32(0), want: true},
+		{name: "int32_not_zero", value: int32(4), want: false},
+
+		{name: "int64_zero", value: int64(0), want: true},
+		{name: "int64_not_zero", value: int64(4), want: false},
+
+		{name: "bool_zero", value: false, want: true},
+		{name: "bool_not_zero", value: true, want: false},
+
+		{name: "uint_zero", value: uint(0), want: true},
+		{name: "uint_not_zero", value: uint(4), want: false},
+
+		{name: "uint8_zero", value: uint8(0), want: true},
+		{name: "uint8_not_zero", value: uint8(4), want: false},
+
+		{name: "uint16_zero", value: uint16(0), want: true},
+		{name: "uint16_not_zero", value: uint16(4), want: false},
+
+		{name: "uint32_zero", value: uint32(0), want: true},
+		{name: "uint32_not_zero", value: uint32(4), want: false},
+
+		{name: "uint64_zero", value: uint64(0), want: true},
+		{name: "uint64_not_zero", value: uint64(4), want: false},
+
+		{name: "float32_zero", value: float32(0), want: true},
+		{name: "float32_not_zero", value: float32(4), want: false},
+
+		{name: "float64_zero", value: float64(0), want: true},
+		{name: "float64_not_zero", value: float64(4), want: false},
+
+		{name: "complex64_zero", value: complex64(0), want: true},
+		{name: "complex64_not_zero", value: complex64(4), want: false},
+
+		{name: "complex128_zero", value: complex128(0), want: true},
+		{name: "complex128_not_zero", value: complex128(4), want: false},
+
+		{name: "slice_zero", value: zeroSlice, want: true},
+		{name: "slice_not_zero", value: []string{}, want: false},
+
+		{name: "map_zero", value: zeroMap, want: true},
+		{name: "map_not_zero", value: map[string]any{}, want: false},
+
+		{name: "struct_zero", value: zeroStruct, want: true},
+		{name: "struct_not_zero", value: Test{V: 123}, want: false},
+
+		{name: "structptr_zero", value: zeroStructPtr, want: true},
+		{name: "structptr_not_zero", value: &Test{}, want: false},
+
+		{name: "bool_zero", value: false, want: true},
+		{name: "bool_not_zero", value: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsZero(tt.value); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasZero(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []any
+		want   bool
+	}{
+		{
+			name:   "no_zeros",
+			values: []any{1, "OK", true},
+			want:   false,
+		},
+		{
+			name:   "some_zeros",
+			values: []any{1, "OK", true, 0, "", false},
+			want:   true,
+		},
+		{
+			name:   "all_zeros",
+			values: []any{0, "", false},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasZero(tt.values...); got != tt.want {
+				t.Errorf("HasZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A pair of functions to check for zero-values have been added to the `validate` package. 

These functions are intended to act as syntactic sugar when checking for zero values, especially in cases where target struct fields cannot be annotated with `validate` tags (e.g. protobuf generated structs).