### PR TITLE
Replace static injection with ClaimInjector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/firestore v1.11.0
 	cloud.google.com/go/storage v1.32.0
-	firebase.google.com/go/v4 v4.12.0
+	firebase.google.com/go/v4 v4.12.1
 	github.com/auth0/go-jwt-middleware v1.0.1
 	github.com/aws/aws-sdk-go v1.44.332
 	github.com/aws/aws-sdk-go-v2 v1.21.0
@@ -19,7 +19,7 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/fsouza/fake-gcs-server v1.45.2
-	github.com/gazebo-web/auth v0.7.0
+	github.com/gazebo-web/auth v0.8.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
 	github.com/golang-jwt/jwt/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ cloud.google.com/go/pubsub v1.33.0 h1:6SPCPvWav64tj0sVX/+npCBKhUi/UjJehy9op/V3p2
 cloud.google.com/go/pubsub v1.33.0/go.mod h1:f+w71I33OMyxf9VpMVcZbnG5KSUkCOUHYpFd5U1GdRc=
 cloud.google.com/go/storage v1.32.0 h1:5w6DxEGOnktmJHarxAOUywxVW9lbNWIzlzzUltG/3+o=
 cloud.google.com/go/storage v1.32.0/go.mod h1:Hhh/dogNRGca7IWv1RC2YqEn0c0G77ctA/OxflYkiD8=
-firebase.google.com/go/v4 v4.12.0 h1:I6dCkcWUMFNkFdWgzlf8SLWecQnKdFgJhMv5fT9l1qI=
-firebase.google.com/go/v4 v4.12.0/go.mod h1:60c36dWLK4+j05Vw5XMllek3b3PCynU3BfI46OSwsUE=
+firebase.google.com/go/v4 v4.12.1 h1:tDNvobifGsx/1HSFLnM0fmNfx/CDZSgsTO2KhZtgpcs=
+firebase.google.com/go/v4 v4.12.1/go.mod h1:60c36dWLK4+j05Vw5XMllek3b3PCynU3BfI46OSwsUE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
@@ -133,8 +133,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.45.2 h1:m4hkghNBY7lmPtpgE41nZa1mOo2PedAZnw3Hd2RfsGk=
 github.com/fsouza/fake-gcs-server v1.45.2/go.mod h1:JDINLKL72GbpnqrtS5cptlcIUDQJlI4iNj4lmh7EvmQ=
-github.com/gazebo-web/auth v0.7.0 h1:ye15JJfvxFU2pg5HrJrqk+Ahad0lJ+3RL/zkqT55N+M=
-github.com/gazebo-web/auth v0.7.0/go.mod h1:/LF0/C20As7uWVXhnf/nszWZmPXEXuxDbmhI/9xaTBY=
+github.com/gazebo-web/auth v0.8.0 h1:TwpFAX9RyZ0uthZ2ubj/svAl7/RzwbxAZIbqim2+OYQ=
+github.com/gazebo-web/auth v0.8.0/go.mod h1:uvecK4glAnlhq+HIKafL/nJdRbrVtw9TKUVQcXhYYJY=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=

--- a/middleware/auth_bearer.go
+++ b/middleware/auth_bearer.go
@@ -52,7 +52,8 @@ type ClaimInjectorJWT func(ctx context.Context, token jwt.Claims) (context.Conte
 // different claim injectors by using GroupClaimInjectors.
 type ClaimInjectorBehavior func(ctx context.Context, err error) (context.Context, error)
 
-// groupClaimInjectors treats all the given injectors as a single one.
+// groupClaimInjectors returns a ClaimInjectorJWT that wraps and calls all provided injectors.
+// This is useful to configure multiple claim injectors for servers with a single function call.
 //
 // By setting a mandatoryInjection, the resulting injector will early return
 // if an error is found at any point during the claim injection.
@@ -106,13 +107,14 @@ func GroupMandatoryClaimInjectors(injectors ...ClaimInjectorJWT) ClaimInjectorJW
 	return groupClaimInjectors(mandatoryInjection, injectors...)
 }
 
-// GroupOptionalClaimInjectors allows injecting optional ClaimInjectors as a single one.
+// GroupOptionalClaimInjectors returns an optional ClaimInjectorJWT that wraps and calls all provided injectors.
+// This is useful to configure multiple optional claim injectors for servers with a single function call.
 // Check groupClaimInjectors to understand how grouping works.
 func GroupOptionalClaimInjectors(injectors ...ClaimInjectorJWT) ClaimInjectorJWT {
 	return groupClaimInjectors(optionalInjection, injectors...)
 }
 
-// SubjectClaimer is a ClaimInjectorJWT for the "sub" claim.
+// SubjectClaimer is a ClaimInjectorJWT that extracts the "sub" claim from an incoming JWT token and stores it in the request context.
 func SubjectClaimer(ctx context.Context, token jwt.Claims) (context.Context, error) {
 	sub, err := token.GetSubject()
 	if err != nil {
@@ -124,7 +126,7 @@ func SubjectClaimer(ctx context.Context, token jwt.Claims) (context.Context, err
 	return InjectGRPCAuthSubject(ctx, sub), nil
 }
 
-// EmailClaimer is a ClaimInjectorJWT for the "email" custom claim.
+// EmailClaimer is a ClaimInjectorJWT that extracts the "email" custom claim from an incoming JWT token and stores it in the request context.
 func EmailClaimer(ctx context.Context, token jwt.Claims) (context.Context, error) {
 	emailClaim, ok := token.(authentication.EmailClaimer)
 	if !ok {

--- a/middleware/auth_bearer.go
+++ b/middleware/auth_bearer.go
@@ -101,7 +101,8 @@ func optionalInjection(ctx context.Context, _ error) (context.Context, error) {
 	return ctx, nil
 }
 
-// GroupMandatoryClaimInjectors allows injecting mandatory ClaimInjectors as a single one.
+// GroupMandatoryClaimInjectors returns a mandatory ClaimInjectorJWT that wraps and calls all provided injectors.
+// This is useful to configure multiple mandatory claim injectors for servers with a single function call.
 // Check groupClaimInjectors to understand how grouping works.
 func GroupMandatoryClaimInjectors(injectors ...ClaimInjectorJWT) ClaimInjectorJWT {
 	return groupClaimInjectors(mandatoryInjection, injectors...)

--- a/middleware/auth_bearer_test.go
+++ b/middleware/auth_bearer_test.go
@@ -154,13 +154,13 @@ func TestAuthFuncGRPC(t *testing.T) {
 		InterceptorTestSuite: &grpc_test.InterceptorTestSuite{
 			TestService: auth,
 			ServerOpts: []grpc.ServerOption{
-				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth, GroupClaimInjectors(MandatoryInjection,
-					GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
-					GroupClaimInjectors(OptionalInjection, EmailClaimer),
+				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth, groupClaimInjectors(mandatoryInjection,
+					groupClaimInjectors(mandatoryInjection, SubjectClaimer),
+					groupClaimInjectors(optionalInjection, EmailClaimer),
 				)))),
-				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth, GroupClaimInjectors(MandatoryInjection,
-					GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
-					GroupClaimInjectors(OptionalInjection, EmailClaimer),
+				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth, groupClaimInjectors(mandatoryInjection,
+					groupClaimInjectors(mandatoryInjection, SubjectClaimer),
+					groupClaimInjectors(optionalInjection, EmailClaimer),
 				)))),
 			},
 		},
@@ -247,7 +247,7 @@ func newTestAuthentication() *testAuthService {
 
 func TestGroupClaimInjectors_Mandatory(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(MandatoryInjection, SubjectClaimer)
+	c := groupClaimInjectors(mandatoryInjection, SubjectClaimer)
 
 	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
 	assert.NoError(t, err)
@@ -259,7 +259,7 @@ func TestGroupClaimInjectors_Mandatory(t *testing.T) {
 
 func TestGroupClaimInjectors_Mandatory_Empty(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(MandatoryInjection, SubjectClaimer)
+	c := groupClaimInjectors(mandatoryInjection, SubjectClaimer)
 
 	// If the token contains an empty subject or it doesn't exist, it must return an error.
 	ctx, err := c(ctx, jwt.MapClaims{})
@@ -272,7 +272,7 @@ func TestGroupClaimInjectors_Mandatory_Empty(t *testing.T) {
 
 func TestGroupClaimInjectors_Optional(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(OptionalInjection, SubjectClaimer)
+	c := groupClaimInjectors(optionalInjection, SubjectClaimer)
 
 	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
 	assert.NoError(t, err)
@@ -284,7 +284,7 @@ func TestGroupClaimInjectors_Optional(t *testing.T) {
 
 func TestGroupClaimInjectors_Optional_Empty(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(OptionalInjection, SubjectClaimer)
+	c := groupClaimInjectors(optionalInjection, SubjectClaimer)
 
 	ctx, err := c(ctx, jwt.MapClaims{})
 	assert.NoError(t, err)
@@ -296,9 +296,9 @@ func TestGroupClaimInjectors_Optional_Empty(t *testing.T) {
 
 func TestGroupClaimInjectors_Combined(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(MandatoryInjection,
-		GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
-		GroupClaimInjectors(OptionalInjection, EmailClaimer),
+	c := GroupMandatoryClaimInjectors(
+		GroupMandatoryClaimInjectors(SubjectClaimer),
+		GroupOptionalClaimInjectors(EmailClaimer),
 	)
 
 	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
@@ -314,9 +314,9 @@ func TestGroupClaimInjectors_Combined(t *testing.T) {
 
 func TestGroupClaimInjectors_Combined_NoEmail(t *testing.T) {
 	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
-	c := GroupClaimInjectors(MandatoryInjection,
-		GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
-		GroupClaimInjectors(OptionalInjection, EmailClaimer),
+	c := GroupMandatoryClaimInjectors(
+		GroupMandatoryClaimInjectors(SubjectClaimer),
+		GroupOptionalClaimInjectors(EmailClaimer),
 	)
 
 	ctx, err := c(ctx, jwt.MapClaims{"sub": "gazebo-web"})

--- a/middleware/auth_bearer_test.go
+++ b/middleware/auth_bearer_test.go
@@ -6,6 +6,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/gazebo-web/auth/pkg/authentication"
 	"github.com/golang-jwt/jwt/v5"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
@@ -17,12 +24,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	grpc_metadata "google.golang.org/grpc/metadata"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestBearerToken_NoAuthorizationHeader(t *testing.T) {
@@ -153,8 +154,14 @@ func TestAuthFuncGRPC(t *testing.T) {
 		InterceptorTestSuite: &grpc_test.InterceptorTestSuite{
 			TestService: auth,
 			ServerOpts: []grpc.ServerOption{
-				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth))),
-				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth))),
+				grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(BearerAuthFuncGRPC(auth, GroupClaimInjectors(MandatoryInjection,
+					GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
+					GroupClaimInjectors(OptionalInjection, EmailClaimer),
+				)))),
+				grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(BearerAuthFuncGRPC(auth, GroupClaimInjectors(MandatoryInjection,
+					GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
+					GroupClaimInjectors(OptionalInjection, EmailClaimer),
+				)))),
 			},
 		},
 	}
@@ -236,4 +243,89 @@ func (s *testAuthService) VerifyJWT(ctx context.Context, token string) (jwt.Clai
 
 func newTestAuthentication() *testAuthService {
 	return &testAuthService{}
+}
+
+func TestGroupClaimInjectors_Mandatory(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(MandatoryInjection, SubjectClaimer)
+
+	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Equal(t, "gazebo-web", subs[0])
+}
+
+func TestGroupClaimInjectors_Mandatory_Empty(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(MandatoryInjection, SubjectClaimer)
+
+	// If the token contains an empty subject or it doesn't exist, it must return an error.
+	ctx, err := c(ctx, jwt.MapClaims{})
+	assert.Error(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Len(t, subs, 0)
+}
+
+func TestGroupClaimInjectors_Optional(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(OptionalInjection, SubjectClaimer)
+
+	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Equal(t, "gazebo-web", subs[0])
+}
+
+func TestGroupClaimInjectors_Optional_Empty(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(OptionalInjection, SubjectClaimer)
+
+	ctx, err := c(ctx, jwt.MapClaims{})
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Len(t, subs, 0)
+}
+
+func TestGroupClaimInjectors_Combined(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(MandatoryInjection,
+		GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
+		GroupClaimInjectors(OptionalInjection, EmailClaimer),
+	)
+
+	ctx, err := c(ctx, authentication.NewFirebaseClaims(authentication.NewFirebaseTestToken()))
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Equal(t, "gazebo-web", subs[0])
+
+	emails := grpc_metadata.ValueFromIncomingContext(ctx, metadataEmailKey)
+	assert.Equal(t, "test@gazebosim.org", emails[0])
+}
+
+func TestGroupClaimInjectors_Combined_NoEmail(t *testing.T) {
+	ctx := grpc_metadata.NewIncomingContext(context.Background(), nil)
+	c := GroupClaimInjectors(MandatoryInjection,
+		GroupClaimInjectors(MandatoryInjection, SubjectClaimer),
+		GroupClaimInjectors(OptionalInjection, EmailClaimer),
+	)
+
+	ctx, err := c(ctx, jwt.MapClaims{"sub": "gazebo-web"})
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	subs := grpc_metadata.ValueFromIncomingContext(ctx, metadataSubjectKey)
+	assert.Equal(t, "gazebo-web", subs[0])
+
+	emails := grpc_metadata.ValueFromIncomingContext(ctx, metadataEmailKey)
+	assert.Empty(t, emails)
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/gazebo-web/auth/pkg/authentication"
 	"github.com/golang-jwt/jwt/v5/request"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	grpc_metadata "google.golang.org/grpc/metadata"
-	"net/http"
 )
 
 // Extractor extracts a string value from an HTTP request. It's usually used to extract a header from an HTTP request,
@@ -64,13 +65,13 @@ const (
 // This function only works with gRPC requests. It returns an error if the metadata couldn't be parsed or the subject
 // is not present.
 func ExtractGRPCAuthSubject(ctx context.Context) (string, error) {
-	return extractGRPCMetadata(ctx, metadataSubjectKey)
+	return ExtractGRPCMetadata(ctx, metadataSubjectKey)
 }
 
 // InjectGRPCAuthSubject injects the authentication subject (sub) claim into the given context metadata.
 // See ExtractGRPCAuthSubject for information on how to extract this value.
 func InjectGRPCAuthSubject(ctx context.Context, sub string) context.Context {
-	return injectGRPCMetadata(ctx, metadataSubjectKey, sub)
+	return InjectGRPCMetadata(ctx, metadataSubjectKey, sub)
 }
 
 // ExtractGRPCAuthEmail extracts the custom email (email) claim from the context metadata. This claim is
@@ -82,17 +83,17 @@ func InjectGRPCAuthSubject(ctx context.Context, sub string) context.Context {
 // This function only works with gRPC requests. It returns an error if the metadata couldn't be parsed or the email
 // is not present.
 func ExtractGRPCAuthEmail(ctx context.Context) (string, error) {
-	return extractGRPCMetadata(ctx, metadataEmailKey)
+	return ExtractGRPCMetadata(ctx, metadataEmailKey)
 }
 
 // InjectGRPCAuthEmail injects the custom email (email) claim into the given context metadata.
 // See ExtractGRPCAuthSubject for information on how to extract this value.
 func InjectGRPCAuthEmail(ctx context.Context, email string) context.Context {
-	return injectGRPCMetadata(ctx, metadataEmailKey, email)
+	return InjectGRPCMetadata(ctx, metadataEmailKey, email)
 }
 
-// extractGRPCMetadata extracts the first value of the given key. This only works for gRPC servers, not clients.
-func extractGRPCMetadata(ctx context.Context, key string) (string, error) {
+// ExtractGRPCMetadata extracts the first value of the given key. This only works for gRPC servers, not clients.
+func ExtractGRPCMetadata(ctx context.Context, key string) (string, error) {
 	md, ok := grpc_metadata.FromIncomingContext(ctx)
 	if !ok {
 		return "", errors.New("failed to get context metadata")
@@ -106,9 +107,9 @@ func extractGRPCMetadata(ctx context.Context, key string) (string, error) {
 	return value, nil
 }
 
-// injectGRPCMetadata injects the given key and value into a context using grpc metadata. This only works for
+// InjectGRPCMetadata injects the given key and value into a context using grpc metadata. This only works for
 // gRPC servers, not clients.
-func injectGRPCMetadata(ctx context.Context, key string, value string) context.Context {
+func InjectGRPCMetadata(ctx context.Context, key string, value string) context.Context {
 	md, ok := grpc_metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ctx


### PR DESCRIPTION
This PR allow us to dynamically inject claims to an incoming `context.Context` by defining a new mechanism called `ClaimInjector`.

An approach similar to what gRPC uses for interceptors has been used to allow developers to set up mandatory and optional injectors.

A function signature has been defined to allow developers creating their own injectors.